### PR TITLE
Python benchmark: optimized worker count, gutted logger out

### DIFF
--- a/python_grpc/server.py
+++ b/python_grpc/server.py
@@ -14,7 +14,6 @@
 """The Python implementation of the GRPC helloworld.Greeter server."""
 
 from concurrent import futures
-import logging
 
 import grpc
 
@@ -25,11 +24,11 @@ import helloworld_pb2_grpc
 class Greeter(helloworld_pb2_grpc.GreeterServicer):
 
     def SayHello(self, request, context):
-        return helloworld_pb2.HelloReply(message='%s' % request.name)
+        return helloworld_pb2.HelloReply(message=request.name)
 
 
 def serve():
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     helloworld_pb2_grpc.add_GreeterServicer_to_server(Greeter(), server)
     server.add_insecure_port('[::]:50051')
     server.start()
@@ -37,5 +36,4 @@ def serve():
 
 
 if __name__ == '__main__':
-    logging.basicConfig()
     serve()


### PR DESCRIPTION
I was able to get 3k on 1 core and 6k on 3 cores with 1 worker. Anything above (e.g. 2) deteriorated the performance. 