### PR TITLE
Use Java 14 (latest GA). Upgrade Gradle. Use ParallelGC by default

### DIFF
--- a/java_grpc_bench/Dockerfile
+++ b/java_grpc_bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM adoptopenjdk:14.0.2_8-jre-hotspot-bionic
 
 WORKDIR /app
 COPY java_grpc_bench /app
@@ -6,6 +6,8 @@ COPY proto/helloworld/helloworld.proto /app/src/main/proto/helloworld.proto
 
 RUN /app/gradlew installDist
 
-ENTRYPOINT [ "/app/build/install/examples/bin/hello-world-server" ]
+ENV PGC "-XX:+UseParallelGC -XX:ParallelGCThreads=1"
+ENV JAVA_OPTS "${PGC} -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70"
 
+ENTRYPOINT [ "/app/build/install/examples/bin/hello-world-server" ]
 

--- a/java_grpc_bench/gradle/wrapper/gradle-wrapper.properties
+++ b/java_grpc_bench/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java_micronaut_bench/Dockerfile
+++ b/java_micronaut_bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM adoptopenjdk:14.0.2_8-jre-hotspot-bionic
 
 WORKDIR /app
 COPY java_micronaut_bench /app
@@ -6,5 +6,8 @@ COPY proto/helloworld/helloworld.proto /app/src/main/proto/helloworld.proto
 
 RUN /app/gradlew installDist
 
-ENTRYPOINT /app/build/install/app/bin/app
+ENV PGC "-XX:+UseParallelGC -XX:ParallelGCThreads=1"
+ENV JAVA_OPTS "${PGC} -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70"
+
+ENTRYPOINT ["/app/build/install/app/bin/app"]
 

--- a/java_micronaut_bench/gradle/wrapper/gradle-wrapper.properties
+++ b/java_micronaut_bench/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlin_grpc_bench/Dockerfile
+++ b/kotlin_grpc_bench/Dockerfile
@@ -1,10 +1,13 @@
-FROM openjdk:8-jdk
+FROM adoptopenjdk:14.0.2_8-jre-hotspot-bionic 
 
 WORKDIR /app
 COPY kotlin_grpc_bench /app
 COPY proto/helloworld/helloworld.proto /app/src/main/proto/hello_world.proto
 
 RUN /app/gradlew installDist
+
+ENV PGC "-XX:+UseParallelGC -XX:ParallelGCThreads=1"
+ENV JAVA_OPTS "${PGC} -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70"
 
 ENTRYPOINT [ "/app/build/install/examples/bin/hello-world-server" ]
 

--- a/kotlin_grpc_bench/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin_grpc_bench/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Java 14 has significant improvements compared to Java 8, and quite a few improvements compared to Java 11.

Java 11 and Java 14 are equally production-ready. The "LTS" label is given by vendors to their specific distributions (binaries) where they provide long term support.