### PR TITLE
fixed swift and go build

### DIFF
--- a/go_grpc_bench/Dockerfile
+++ b/go_grpc_bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.15
 
 WORKDIR /app
 COPY go_grpc_bench /app

--- a/go_grpc_bench/go.mod
+++ b/go_grpc_bench/go.mod
@@ -1,11 +1,11 @@
 module example
 
-go 1.11
+go 1.15
 
 require (
 	github.com/golang/mock v1.1.1
 	github.com/golang/protobuf v1.4.2
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	google.golang.org/genproto v0.0.0-20200624020401-64a14ca9d1ad
-	google.golang.org/grpc v1.30.0
+	google.golang.org/grpc v1.29.1
 )

--- a/swift_grpc_bench/Sources/Model/helloworld.grpc.swift
+++ b/swift_grpc_bench/Sources/Model/helloworld.grpc.swift
@@ -78,11 +78,11 @@ public protocol Helloworld_GreeterProvider: CallHandlerProvider {
 }
 
 extension Helloworld_GreeterProvider {
-  public var serviceName: String { return "helloworld.Greeter" }
+  public var serviceName: Substring { return "helloworld.Greeter" }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(_ methodName: String, callHandlerContext: CallHandlerContext) -> GRPCCallHandler? {
+  public func handleMethod(_ methodName: Substring, callHandlerContext: CallHandlerContext) -> GRPCCallHandler? {
     switch methodName {
     case "SayHello":
       return CallHandlerFactory.makeUnary(callHandlerContext: callHandlerContext) { context in


### PR DESCRIPTION
Swift build is failing on master

```
#10 74.32 /app/Sources/Server/GreeterProvider.swift:20:7: error: type 'GreeterProvider' does not conform to protocol 'CallHandlerProvider'                                                                                                                                                  
#10 74.32 class GreeterProvider: Helloworld_GreeterProvider {                                                                                                                                                                                                                               
#10 74.32       ^                                                                                                                                                                                                                                                                           
#10 74.32 /app/Sources/Model/helloworld.grpc.swift:85:15: note: candidate has non-matching type '<Self> (String, callHandlerContext: CallHandlerContext) -> GRPCCallHandler?'                                                                                                               
#10 74.32   public func handleMethod(_ methodName: String, callHandlerContext: CallHandlerContext) -> GRPCCallHandler? {                                                                                                                                                                    
#10 74.32               ^                                                                                                                                                                                                                                                                   
#10 74.32 /app/.build/checkouts/grpc-swift/Sources/GRPC/GRPCServerRequestRoutingHandler.swift:37:8: note: protocol requires function 'handleMethod(_:callHandlerContext:)' with type '(Substring, CallHandlerContext) -> GRPCCallHandler?'                                                  
#10 74.32   func handleMethod(_ methodName: Substring, callHandlerContext: CallHandlerContext)                                                                                                                                                                                              
#10 74.32        ^                                                                                                                                                                                                                                                                          
#10 ERROR: executor failed running [/bin/sh -c swift build -c release]: runc did not terminate sucessfully  
```