### PR TITLE
Update the Swift benchmark for compatibility with the latest gRPC-Swift.

### DIFF
--- a/swift_grpc_bench/Dockerfile
+++ b/swift_grpc_bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.2
+FROM swift:5.3-focal
 
 WORKDIR /app
 

--- a/swift_grpc_bench/Sources/Model/helloworld.pb.swift
+++ b/swift_grpc_bench/Sources/Model/helloworld.pb.swift
@@ -47,7 +47,7 @@ public struct Helloworld_HelloRequest {
   public init() {}
 }
 
-/// The response message containing the greetings.
+/// The response message containing the greetings
 public struct Helloworld_HelloReply {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for

--- a/swift_grpc_bench/Sources/Server/GreeterProvider.swift
+++ b/swift_grpc_bench/Sources/Server/GreeterProvider.swift
@@ -18,6 +18,8 @@ import HelloWorldModel
 import NIO
 
 class GreeterProvider: Helloworld_GreeterProvider {
+  var interceptors: Helloworld_GreeterServerInterceptorFactoryProtocol? { nil }
+  
   func sayHello(
     request: Helloworld_HelloRequest,
     context: StatusOnlyCallContext


### PR DESCRIPTION
Results on an i7-6700k (OC to 4.5 GHz) running Docker on macOS 10.15:

```
$ GRPC_BENCHMARK_DURATION=5s GRPC_SERVER_CPUS=1 ./bench.sh swift_grpc_bench                                                                                                           0.0.1: Pulling from infoblox/ghz
Digest: sha256:ce02c4410816d3dfc8497dfd38f0f5100cf04aa6e7de8645228430ca49d62f41
Status: Image is up to date for infoblox/ghz:0.0.1
docker.io/infoblox/ghz:0.0.1
==> Running benchmark for swift_grpc_bench...
    Requests/sec:	9611.98
-----
Benchmark finished. Detailed results are located in: results/212402T155917
--------------------------------------------------------------------------------------------------------------------------------
| name               |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
--------------------------------------------------------------------------------------------------------------------------------
| swift_grpc         |    9603 |        5.13 ms |        6.43 ms |        7.29 ms |       54.62 ms |   61.44% |      2.45 MiB |
--------------------------------------------------------------------------------------------------------------------------------
All done.
$ GRPC_BENCHMARK_DURATION=5s GRPC_SERVER_CPUS=2 GRPC_CLIENT_CPUS=2 ./bench.sh swift_grpc_bench                                                                                        0.0.1: Pulling from infoblox/ghz
Digest: sha256:ce02c4410816d3dfc8497dfd38f0f5100cf04aa6e7de8645228430ca49d62f41
Status: Image is up to date for infoblox/ghz:0.0.1
docker.io/infoblox/ghz:0.0.1
==> Running benchmark for swift_grpc_bench...
    Requests/sec:	19215.65
-----
Benchmark finished. Detailed results are located in: results/212402T160050
--------------------------------------------------------------------------------------------------------------------------------
| name               |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
--------------------------------------------------------------------------------------------------------------------------------
| swift_grpc         |   19209 |        2.54 ms |        3.75 ms |        4.24 ms |        7.62 ms |  188.33% |      2.64 MiB |
--------------------------------------------------------------------------------------------------------------------------------
All done.
$ GRPC_BENCHMARK_DURATION=5s GRPC_SERVER_CPUS=1 GRPC_CLIENT_CPUS=2 ./bench.sh swift_grpc_bench                                                                                        0.0.1: Pulling from infoblox/ghz
Digest: sha256:ce02c4410816d3dfc8497dfd38f0f5100cf04aa6e7de8645228430ca49d62f41
Status: Image is up to date for infoblox/ghz:0.0.1
docker.io/infoblox/ghz:0.0.1
==> Running benchmark for swift_grpc_bench...
    Requests/sec:	11360.64
-----
Benchmark finished. Detailed results are located in: results/212402T160118
--------------------------------------------------------------------------------------------------------------------------------
| name               |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
--------------------------------------------------------------------------------------------------------------------------------
| swift_grpc         |   11348 |        4.36 ms |        6.42 ms |        6.88 ms |        8.99 ms |  103.49% |      2.43 MiB |
--------------------------------------------------------------------------------------------------------------------------------
All done.
```

I.e. roughly a 2x speedup over https://github.com/LesnyRumcajs/grpc_bench/pull/87.