### PR TITLE
Add `-Xswiftc -enforce-exclusivity=unchecked` to Swift builds.

### DIFF
--- a/swift_grpc_bench/Dockerfile
+++ b/swift_grpc_bench/Dockerfile
@@ -8,6 +8,6 @@ COPY swift_grpc_bench/Package.swift /app
 RUN swift package resolve
 
 COPY swift_grpc_bench /app
-RUN swift build -c release
+RUN swift build -c release -Xswiftc -enforce-exclusivity=unchecked
 
 ENTRYPOINT [ "/app/.build/release/Server" ]


### PR DESCRIPTION
See https://github.com/LesnyRumcajs/grpc_bench/pull/108#issuecomment-785812980 for discussion and performance numbers.