### PR TITLE
Improved CPP MT CPU usage, jthread for thread

### DIFF
--- a/cpp_grpc_mt_bench/Dockerfile
+++ b/cpp_grpc_mt_bench/Dockerfile
@@ -9,6 +9,6 @@ COPY proto /app/proto
 RUN mkdir gen && \
     protoc --proto_path=/app/proto/helloworld --cpp_out=gen helloworld.proto && \
     protoc --proto_path=/app/proto/helloworld --grpc_out=gen --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` helloworld.proto
-RUN g++ -O3 -flto main.cpp gen/helloworld.grpc.pb.cc gen/helloworld.pb.cc -Igen -lgrpc++ -lprotobuf -lgrpc -lpthread
+RUN g++ --std=c++20 -O3 -flto main.cpp gen/helloworld.grpc.pb.cc gen/helloworld.pb.cc -Igen -lgrpc++ -lprotobuf -lgrpc -lpthread
 
 ENTRYPOINT /app/a.out

--- a/cpp_grpc_mt_bench/main.cpp
+++ b/cpp_grpc_mt_bench/main.cpp
@@ -47,11 +47,6 @@ class ServerImpl final {
     // Always shutdown the completion queue after the server.
     for (auto& cq : cq_)
       cq->Shutdown();
-
-    for (auto& thread : server_threads_) {
-      if (thread.joinable())
-        thread.join();
-    }
   }
 
   // There is no shutdown handling in this code.
@@ -76,10 +71,10 @@ class ServerImpl final {
 
     // Proceed to the server's main loop.
     for (int i = 0; i < parallelism; i++) {
-      server_threads_.emplace_back(std::thread([this, i] { this->HandleRpcs(i); }));
+      server_threads_.emplace_back(std::jthread([this, i] { this->HandleRpcs(i); }));
     }
 
-    for (;;) {}
+    std::this_thread::sleep_until(std::chrono::time_point<std::chrono::system_clock>::max());
   }
 
  private:
@@ -173,7 +168,7 @@ class ServerImpl final {
   std::vector<std::unique_ptr<ServerCompletionQueue>> cq_;
   Greeter::AsyncService service_;
   std::unique_ptr<Server> server_;
-  std::vector<std::thread> server_threads_;
+  std::vector<std::jthread> server_threads_;
 };
 
 int main(int argc, char** argv) {

--- a/proto/helloworld/helloworld.proto
+++ b/proto/helloworld/helloworld.proto
@@ -14,6 +14,7 @@
 
 syntax = "proto3";
 
+option go_package = "proto/helloworld";
 option java_multiple_files = true;
 option java_package = "io.grpc.examples.helloworld";
 option java_outer_classname = "HelloWorldProto";


### PR DESCRIPTION
1. `jthread` should join without boilerplate in the dtor
2. infinite loop without any sleeps utilised 100% cpu no matter the load, replaced with sleep till the end of times