### PR TITLE
Set threads on  rust_tonic_mt_bench

### DIFF
--- a/rust_tonic_mt_bench/.cargo/config
+++ b/rust_tonic_mt_bench/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = [ "-C", "target-cpu=native" ]

--- a/rust_tonic_mt_bench/src/main.rs
+++ b/rust_tonic_mt_bench/src/main.rs
@@ -23,8 +23,24 @@ impl Greeter for MyGreeter {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cpus = std::env::var("GRPC_SERVER_CPUS")
+        .map(|v| v.parse().unwrap())
+        .unwrap_or(1);
+    
+    println!("Running with {} threads", cpus);
+
+    // Esentially the same as tokio::main, but with number of threads set to 
+    // avoid thrashing when cggroup limits are applied by Docker.
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(cpus)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(serve())
+}
+
+async fn serve() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "0.0.0.0:50051".parse().unwrap();
     let greeter = MyGreeter::default();
 

--- a/rust_tonic_st_bench/.cargo/config
+++ b/rust_tonic_st_bench/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = [ "-C", "target-cpu=native" ]


### PR DESCRIPTION
Currently, `rust_tonic_mt_bench` uses the `#[tokio::main]` annotation to configure tokio, so it'll just land up using as many threads as there are processors on the system. In my case, 24 threads. The benchmark however sets a `cggroup` limit, so we land up running 24 threads on effectively e.g. 3 processors.

This PR simply sets up tokio in a similar way to the annotation, but sets the number of worker threads as supplied in the environment.

The change is not required for `rust_tonic_st_bench` as it's limited to a single thread anyway. 

Changes
- set threads on tonic mt executor to match container limits
- compile for appropriate processor for slight performance improvement

## Results

Using the following benchmark parameters, running on a Ryzen 3900X, 
```
GRPC_BENCHMARK_DURATION=30s
GRPC_SERVER_CPUS=3
GRPC_SERVER_RAM=512m
GRPC_CLIENT_CONNECTIONS=5
GRPC_CLIENT_CONCURRENCY=50
GRPC_CLIENT_QPS=0
GRPC_CLIENT_CPUS=9
GRPC_REQUEST_PAYLOAD=100B
```

### Before
```
--------------------------------------------------------------------------------------------------------------------------------
| name               |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
--------------------------------------------------------------------------------------------------------------------------------
| rust_tonic_st      |   66591 |        0.72 ms |        1.00 ms |        1.09 ms |        1.37 ms |   99.65% |      4.51 MiB |
| dotnet_grpc        |   63444 |        0.75 ms |        0.85 ms |        0.99 ms |        2.55 ms |   298.4% |     103.4 MiB |
| java_grpc_pgc      |   60051 |        0.78 ms |        0.75 ms |        1.04 ms |        4.13 ms |  197.26% |     165.8 MiB |
| rust_tonic_mt      |   29342 |        1.65 ms |        1.04 ms |        1.30 ms |       61.00 ms |  302.78% |     10.55 MiB |
--------------------------------------------------------------------------------------------------------------------------------
```

### After
```
--------------------------------------------------------------------------------------------------------------------------------
| name               |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
--------------------------------------------------------------------------------------------------------------------------------
| rust_tonic_st      |   67567 |        0.71 ms |        0.99 ms |        1.08 ms |        1.37 ms |  101.42% |      4.55 MiB |
| rust_tonic_mt      |   66037 |        0.72 ms |        1.11 ms |        1.26 ms |        1.64 ms |  279.68% |      5.42 MiB |
| dotnet_grpc        |   64151 |        0.74 ms |        0.85 ms |        0.99 ms |        2.51 ms |  300.26% |     106.6 MiB |
| java_grpc_pgc      |   59977 |        0.78 ms |        0.74 ms |        1.05 ms |        3.94 ms |  197.17% |    103.81 MiB |
--------------------------------------------------------------------------------------------------------------------------------
```
