### PR TITLE
Use mimalloc and target-cpu=native in rust tonic_st and grpcio

### DIFF
--- a/rust_grpcio_bench/Cargo.lock
+++ b/rust_grpcio_bench/Cargo.lock
@@ -324,6 +324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2396cf99d2f58611cd69f0efeee4af3d2e2c7b61bed433515029163aa567e65c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +367,15 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7c6b11afd1e5e689ac96b6d18b1fc763398fe3d7eed99e8773426bc2033dfb"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -588,6 +606,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "grpcio",
+ "mimalloc",
  "protobuf",
  "protoc-grpcio",
 ]

--- a/rust_grpcio_bench/Cargo.toml
+++ b/rust_grpcio_bench/Cargo.toml
@@ -13,6 +13,7 @@ lto = true
 grpcio = "0.8"
 protobuf = "~2"
 futures = "0.3"
+mimalloc = { version = "0.1", default-features = false }
 
 [build-dependencies]
 protoc-grpcio = "3.0"

--- a/rust_grpcio_bench/Dockerfile
+++ b/rust_grpcio_bench/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY rust_grpcio_bench /app
 COPY proto /app/src/proto
 
+ENV RUSTFLAGS="-C target-cpu=native"
 RUN cargo build --release
 
-ENTRYPOINT cargo run --release
+ENTRYPOINT ["./target/release/helloworld-server"]

--- a/rust_grpcio_bench/src/main.rs
+++ b/rust_grpcio_bench/src/main.rs
@@ -4,6 +4,7 @@ use std::io::Read;
 use std::sync::Arc;
 use std::{io, thread};
 
+use mimalloc::MiMalloc;
 use futures::channel::oneshot;
 use futures::executor::block_on;
 use futures::prelude::*;
@@ -11,6 +12,9 @@ use grpcio::{ChannelBuilder, Environment, RpcContext, ServerBuilder, UnarySink};
 
 use crate::proto::gen::helloworld::{HelloReply, HelloRequest};
 use crate::proto::gen::helloworld_grpc::{create_greeter, Greeter};
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[derive(Clone)]
 struct GreeterService;

--- a/rust_tonic_st_bench/Cargo.lock
+++ b/rust_tonic_st_bench/Cargo.lock
@@ -63,6 +63,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
+name = "cc"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2396cf99d2f58611cd69f0efeee4af3d2e2c7b61bed433515029163aa567e65c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +311,15 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7c6b11afd1e5e689ac96b6d18b1fc763398fe3d7eed99e8773426bc2033dfb"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mio"
@@ -577,6 +601,7 @@ dependencies = [
 name = "rust_tonic"
 version = "0.1.0"
 dependencies = [
+ "mimalloc",
  "prost",
  "tokio",
  "tonic",

--- a/rust_tonic_st_bench/Cargo.toml
+++ b/rust_tonic_st_bench/Cargo.toml
@@ -13,6 +13,7 @@ lto = true
 tonic = "0.4"
 prost = "0.7"
 tokio = { version = "1.4", features = ["rt", "macros", "io-util"] }
+mimalloc = { version = "0.1", default-features = false }
 
 [build-dependencies]
 tonic-build = "0.4"

--- a/rust_tonic_st_bench/Dockerfile
+++ b/rust_tonic_st_bench/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /app
 COPY rust_tonic_st_bench /app
 COPY proto /app/proto
 
+ENV RUSTFLAGS="-C target-cpu=native"
+
 RUN rustup component add rustfmt
 RUN cargo build --release
 
 ENTRYPOINT cargo run --release
+ENTRYPOINT ["./target/release/helloworld-server"]

--- a/rust_tonic_st_bench/src/main.rs
+++ b/rust_tonic_st_bench/src/main.rs
@@ -1,7 +1,11 @@
+use mimalloc::MiMalloc;
 use tonic::{transport::Server, Request, Response, Status};
 
 use hello_world::greeter_server::{Greeter, GreeterServer};
 use hello_world::{HelloReply, HelloRequest};
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");


### PR DESCRIPTION
I ran the CI benchmark before/after the change (Only for rust, ruby and java because of https://github.com/LesnyRumcajs/grpc_bench/issues/126)

before: https://github.com/nico-abram/grpc_bench/issues/6
after: https://github.com/nico-abram/grpc_bench/issues/5

I am on a windows box without docker or wsl so I couldn't run the benchmarks locally. I don't see any significant changes in the CI benchmark but I have a feeling using mimalloc could significantly improve the multithreaded benchmark