### PR TITLE
Update ghz to 0.102.0

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -27,8 +27,6 @@ export GRPC_REQUEST_PAYLOAD=${GRPC_REQUEST_PAYLOAD:-"100B"}
 # export GRPC_CLIENT_CONCURRENCY
 # export GRPC_CLIENT_QPS
 
-docker pull infoblox/ghz:0.0.1
-
 # Loop over benchs
 for benchmark in ${BENCHMARKS_TO_RUN}; do
 	NAME="${benchmark##*/}"
@@ -60,7 +58,7 @@ for benchmark in ${BENCHMARKS_TO_RUN}; do
             --insecure \
             --concurrency="${GRPC_CLIENT_CONCURRENCY}" \
             --connections="${GRPC_CLIENT_CONNECTIONS}" \
-            --qps="${GRPC_CLIENT_QPS}" \
+            --rps="${GRPC_CLIENT_QPS}" \
             --duration "${GRPC_BENCHMARK_WARMUP}" \
             --data-file /payload/"${GRPC_REQUEST_PAYLOAD}" \
     		127.0.0.1:50051 > /dev/null
@@ -86,7 +84,7 @@ for benchmark in ${BENCHMARKS_TO_RUN}; do
         --insecure \
         --concurrency="${GRPC_CLIENT_CONCURRENCY}" \
         --connections="${GRPC_CLIENT_CONNECTIONS}" \
-        --qps="${GRPC_CLIENT_QPS}" \
+        --rps="${GRPC_CLIENT_QPS}" \
         --duration "${GRPC_BENCHMARK_DURATION}" \
         --data-file /payload/"${GRPC_REQUEST_PAYLOAD}" \
 		127.0.0.1:50051 >"${RESULTS_DIR}/${NAME}".report

--- a/ghz-tool/Dockerfile
+++ b/ghz-tool/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu
 
 RUN apt-get -q update \
     && apt-get -q -y install wget \
-    && wget https://github.com/bojand/ghz/releases/download/v0.58.0/ghz-linux-x86_64.tar.gz \
+    && wget https://github.com/bojand/ghz/releases/download/v0.102.0/ghz-linux-x86_64.tar.gz \
     && tar zxf ghz-linux-x86_64.tar.gz -C /usr/bin \
     && apt-get -q -y remove wget \
     && apt-get -q -y autoremove \


### PR DESCRIPTION
Also remove the `docker pull infoblox/ghz:0.0.1` statement from `bench.sh`, since I could not see any use for it.

The command-line argument `--qps` has been renamed to `--rps`. The environment variable `GRPC_CLIENT_QPS` was left unchanged.