### PR TITLE
Add asio-grpc benchmark

### DIFF
--- a/cpp_asio_grpc_bench/.dockerignore
+++ b/cpp_asio_grpc_bench/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/cpp_asio_grpc_bench/CMakeLists.txt
+++ b/cpp_asio_grpc_bench/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(
+  cpp_asio_grpc_bench
+  DESCRIPTION "Benchmark for asio-grpc"
+  HOMEPAGE_URL https://github.com/Tradias/asio-grpc
+  LANGUAGES CXX)
+
+include(FindPkgConfig)
+
+pkg_check_modules(grpc++_unsecure REQUIRED IMPORTED_TARGET grpc++_unsecure)
+pkg_check_modules(protobuf REQUIRED IMPORTED_TARGET protobuf)
+find_package(Boost REQUIRED COMPONENTS coroutine)
+
+add_executable(${PROJECT_NAME})
+
+target_sources(
+  ${PROJECT_NAME}
+  PRIVATE main.cpp "${CMAKE_CURRENT_LIST_DIR}/gen/helloworld.pb.cc"
+          "${CMAKE_CURRENT_LIST_DIR}/gen/helloworld.grpc.pb.cc")
+
+target_link_libraries(
+  ${PROJECT_NAME} PRIVATE PkgConfig::grpc++_unsecure PkgConfig::protobuf
+                          Boost::headers Boost::coroutine)
+
+target_include_directories(${PROJECT_NAME}
+                           PRIVATE "${CMAKE_CURRENT_LIST_DIR}/gen")
+
+target_compile_options(${PROJECT_NAME} PRIVATE -flto)
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE BOOST_ASIO_NO_DEPRECATED)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+install(TARGETS ${PROJECT_NAME})

--- a/cpp_asio_grpc_bench/Dockerfile
+++ b/cpp_asio_grpc_bench/Dockerfile
@@ -1,0 +1,45 @@
+FROM gcc:11
+
+RUN apt-get update && apt-get install -y \
+    wget \
+    make \
+    libprotobuf-dev \
+    libgrpc++-dev \
+    protobuf-compiler \
+    protobuf-compiler-grpc \
+    libboost-dev \
+    libboost-coroutine-dev
+
+WORKDIR /app
+
+ARG CMAKE_VERSION=3.21.2
+RUN wget --no-verbose https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh \
+    && chmod +x ./cmake-${CMAKE_VERSION}-linux-x86_64.sh \
+    && ./cmake-${CMAKE_VERSION}-linux-x86_64.sh --skip-license --prefix=/usr
+
+ARG ASIO_GRPC_VERSION=1.0.0
+RUN wget --no-verbose https://github.com/Tradias/asio-grpc/archive/refs/tags/v${ASIO_GRPC_VERSION}.tar.gz \
+    && tar zxf v${ASIO_GRPC_VERSION}.tar.gz -C /app \
+    && cd asio-grpc-${ASIO_GRPC_VERSION} \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && cmake --build . --target install
+
+COPY proto /app/proto
+RUN mkdir gen \
+    && protoc --proto_path=/app/proto/helloworld --cpp_out=gen helloworld.proto \
+    && protoc --proto_path=/app/proto/helloworld --grpc_out=gen --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` helloworld.proto
+
+COPY cpp_asio_grpc_bench /app
+RUN mkdir build \
+    && cd build \
+    && cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/app/out \
+        .. \
+    && cmake --build . --config=Release --parallel=3 --target install
+
+EXPOSE 50051
+
+ENTRYPOINT ["/app/out/bin/cpp_asio_grpc_bench"]

--- a/cpp_asio_grpc_bench/main.cpp
+++ b/cpp_asio_grpc_bench/main.cpp
@@ -1,0 +1,95 @@
+// Copyright 2021 Dennis Hezel
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "helloworld.grpc.pb.h"
+
+#include <agrpc/asioGrpc.hpp>
+#include <boost/asio/spawn.hpp>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+
+#include <forward_list>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+struct UnaryRPCContext {
+  grpc::ServerContext server_context;
+  helloworld::HelloRequest request;
+  grpc::ServerAsyncResponseWriter<helloworld::HelloReply> writer{
+      &server_context};
+};
+
+void spawn_accept_loop(
+    agrpc::GrpcContext &grpc_context,
+    helloworld::Greeter::AsyncService &service,
+    boost::asio::executor_work_guard<agrpc::GrpcContext::executor_type>
+        &guard) {
+  boost::asio::spawn(grpc_context, [&](auto yield) {
+    bool request_ok{true};
+    while (request_ok) {
+      auto context =
+          std::allocate_shared<UnaryRPCContext>(grpc_context.get_allocator());
+      request_ok = agrpc::request(
+          &helloworld::Greeter::AsyncService::RequestSayHello, service,
+          context->server_context, context->request, context->writer, yield);
+      if (!request_ok) {
+        guard.reset();
+        return;
+      }
+      helloworld::HelloReply response;
+      response.set_message(context->request.name());
+      auto &writer = context->writer;
+      agrpc::finish(writer, response, grpc::Status::OK,
+                    boost::asio::bind_executor(
+                        grpc_context, [context = std::move(context)]() {}));
+    }
+  });
+}
+
+int main() {
+  std::string server_address("0.0.0.0:50051");
+
+  grpc::ServerBuilder builder;
+  std::unique_ptr<grpc::Server> server;
+  helloworld::Greeter::AsyncService service;
+
+  const auto parallelism = std::atoi(std::getenv("GRPC_SERVER_CPUS"));
+  std::forward_list<agrpc::GrpcContext> grpc_contexts;
+  for (int i = 0; i < parallelism; ++i) {
+    grpc_contexts.emplace_front(builder.AddCompletionQueue());
+  }
+
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  builder.RegisterService(&service);
+  server = builder.BuildAndStart();
+  std::cout << "Server listening on " << server_address << std::endl;
+
+  std::vector<std::thread> threads;
+  threads.reserve(parallelism);
+  for (int i = 0; i < parallelism; ++i) {
+    threads.emplace_back([&, i] {
+      auto &grpc_context = *std::next(grpc_contexts.begin(), i);
+      auto guard = boost::asio::make_work_guard(grpc_context);
+      spawn_accept_loop(grpc_context, service, guard);
+      grpc_context.run();
+    });
+  }
+
+  for (auto &thread : threads) {
+    thread.join();
+  }
+
+  server->Shutdown();
+}

--- a/cpp_grpc_mt_bench/Dockerfile
+++ b/cpp_grpc_mt_bench/Dockerfile
@@ -1,6 +1,6 @@
-FROM gcc:10
+FROM gcc:11
 
-RUN apt update && apt install -y protobuf-compiler protobuf-compiler-grpc libgrpc++-dev
+RUN apt-get update && apt-get install -y protobuf-compiler protobuf-compiler-grpc libgrpc++-dev
 
 WORKDIR /app
 COPY cpp_grpc_mt_bench /app

--- a/cpp_grpc_st_bench/Dockerfile
+++ b/cpp_grpc_st_bench/Dockerfile
@@ -1,6 +1,6 @@
-FROM gcc:10
+FROM gcc:11
 
-RUN apt update && apt install -y protobuf-compiler protobuf-compiler-grpc libgrpc++-dev
+RUN apt-get update && apt-get install -y protobuf-compiler protobuf-compiler-grpc libgrpc++-dev
 
 WORKDIR /app
 COPY cpp_grpc_st_bench /app


### PR DESCRIPTION
Add benchmark for https://github.com/Tradias/asio-grpc.

I tried to keep the Dockerfile as quick to build as possible, at the expense of not using the latest versions of gRPC and Boost.

Also bumped docker base image versions of the other C++ benchmarks to `gcc:11` for better comparison.