### PR TITLE
Bump Go

### DIFF
--- a/go_grpc_bench/Dockerfile
+++ b/go_grpc_bench/Dockerfile
@@ -8,9 +8,7 @@ RUN apt update && apt install -y protobuf-compiler
 RUN go get google.golang.org/protobuf/cmd/protoc-gen-go
 RUN go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
-
-RUN mkdir -p /app/vendor
 RUN protoc -I /app/proto/helloworld /app/proto/helloworld/helloworld.proto --go-grpc_out=/app/ --go_out=/app/
-RUN go mod tidy && go mod vendor && go build ./... && go install ./...
+RUN go mod tidy && go build ./... && go install ./...
 
 ENTRYPOINT example

--- a/go_grpc_bench/Dockerfile
+++ b/go_grpc_bench/Dockerfile
@@ -1,12 +1,16 @@
-FROM golang:1.15
+FROM golang:1.17
 
 WORKDIR /app
 COPY go_grpc_bench /app
 COPY proto /app/proto
 
 RUN apt update && apt install -y protobuf-compiler
-RUN go get -u github.com/golang/protobuf/protoc-gen-go
-RUN protoc -I /app/proto/helloworld /app/proto/helloworld/helloworld.proto --go_out=plugins=grpc:/app/proto/helloworld
-RUN go build ./... && go install ./...
+RUN go get google.golang.org/protobuf/cmd/protoc-gen-go
+RUN go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
+
+
+RUN mkdir -p /app/vendor
+RUN protoc -I /app/proto/helloworld /app/proto/helloworld/helloworld.proto --go-grpc_out=/app/ --go_out=/app/
+RUN go mod tidy && go mod vendor && go build ./... && go install ./...
 
 ENTRYPOINT example

--- a/go_grpc_bench/example/main.go
+++ b/go_grpc_bench/example/main.go
@@ -25,7 +25,7 @@ import (
 	"net"
 
 	"google.golang.org/grpc"
-	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+	pb "local/proto/helloworld"
 )
 
 const (

--- a/go_grpc_bench/go.mod
+++ b/go_grpc_bench/go.mod
@@ -1,11 +1,12 @@
 module example
 
-go 1.15
+go 1.17
 
 require (
-	github.com/golang/mock v1.1.1
-	github.com/golang/protobuf v1.4.2
-	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
-	google.golang.org/genproto v0.0.0-20200624020401-64a14ca9d1ad
-	google.golang.org/grpc v1.29.1
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98
+	google.golang.org/grpc v1.36.0
+	google.golang.org/protobuf v1.27.1
 )
+
+replace local => ./


### PR DESCRIPTION
Previous version was actually downloading the compiled protobuf package and not using what we compiled. Now we're using the local one. Changed some deprecated parts and bumped the versions where I could. Looks promising.

```
-----------------------------------------------------------------------------------------------------------------------------------------
| name                        |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
-----------------------------------------------------------------------------------------------------------------------------------------
| go_grpc_bump                |   30329 |       28.30 ms |       72.73 ms |       86.93 ms |      129.37 ms |  195.35% |     30.13 MiB |
| go_grpc                     |   20374 |       43.18 ms |       95.35 ms |      114.59 ms |      183.94 ms |  192.13% |     26.98 MiB |
-----------------------------------------------------------------------------------------------------------------------------------------
```