### PR TITLE
use jemalloc for cpp benches

### DIFF
--- a/cpp_asio_grpc_bench/Dockerfile
+++ b/cpp_asio_grpc_bench/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y \
     protobuf-compiler \
     protobuf-compiler-grpc \
     libboost-dev \
-    libboost-coroutine-dev
+    libboost-coroutine-dev \
+    libjemalloc-dev
 
 WORKDIR /app
 
@@ -37,6 +38,8 @@ RUN mkdir build \
     && cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/app/out \
+        -DCMAKE_C_FLAGS="-ljemalloc" \
+        -DCMAKE_CXX_FLAGS="-ljemalloc" \
         .. \
     && cmake --build . --config=Release --parallel=3 --target install
 

--- a/cpp_grpc_mt_bench/Dockerfile
+++ b/cpp_grpc_mt_bench/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcc:11
 
-RUN apt-get update && apt-get install -y protobuf-compiler protobuf-compiler-grpc libgrpc++-dev
+RUN apt-get update && apt-get install -y protobuf-compiler protobuf-compiler-grpc libgrpc++-dev libjemalloc-dev
 
 WORKDIR /app
 COPY cpp_grpc_mt_bench /app
@@ -9,6 +9,6 @@ COPY proto /app/proto
 RUN mkdir gen && \
     protoc --proto_path=/app/proto/helloworld --cpp_out=gen helloworld.proto && \
     protoc --proto_path=/app/proto/helloworld --grpc_out=gen --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` helloworld.proto
-RUN g++ --std=c++20 -O3 -flto main.cpp gen/helloworld.grpc.pb.cc gen/helloworld.pb.cc -Igen -lgrpc++ -lprotobuf -lgrpc -lpthread
+RUN g++ --std=c++20 -O3 -flto main.cpp gen/helloworld.grpc.pb.cc gen/helloworld.pb.cc -Igen -lgrpc++ -lprotobuf -lgrpc -lpthread -ljemalloc
 
 ENTRYPOINT /app/a.out

--- a/cpp_grpc_st_bench/Dockerfile
+++ b/cpp_grpc_st_bench/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcc:11
 
-RUN apt-get update && apt-get install -y protobuf-compiler protobuf-compiler-grpc libgrpc++-dev
+RUN apt-get update && apt-get install -y protobuf-compiler protobuf-compiler-grpc libgrpc++-dev libjemalloc-dev
 
 WORKDIR /app
 COPY cpp_grpc_st_bench /app
@@ -9,6 +9,6 @@ COPY proto /app/proto
 RUN mkdir gen && \
     protoc --proto_path=/app/proto/helloworld --cpp_out=gen helloworld.proto && \
     protoc --proto_path=/app/proto/helloworld --grpc_out=gen --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` helloworld.proto
-RUN g++ -O3 -flto main.cpp gen/helloworld.grpc.pb.cc gen/helloworld.pb.cc -Igen -lgrpc++ -lprotobuf -lgrpc
+RUN g++ -O3 -flto main.cpp gen/helloworld.grpc.pb.cc gen/helloworld.pb.cc -Igen -lgrpc++ -lprotobuf -lgrpc -ljemalloc
 
 ENTRYPOINT /app/a.out


### PR DESCRIPTION
Seems to slightly beat standard allocator at the cost of increased memory.
```
-----------------------------------------------------------------------------------------------------------------------------------------
| name                        |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
-----------------------------------------------------------------------------------------------------------------------------------------
| cpp_grpc_mt_jemalloc        |   74164 |       11.92 ms |       20.74 ms |       24.59 ms |       34.70 ms |  200.87% |     31.85 MiB |
| cpp_grpc_mt                 |   71805 |       12.74 ms |       22.18 ms |       26.06 ms |       35.20 ms |  200.99% |     26.85 MiB |
| cpp_grpc_st_jemalloc        |   31886 |       31.30 ms |       34.04 ms |       34.49 ms |       35.50 ms |   86.24% |       8.8 MiB |
| cpp_grpc_st                 |   31842 |       31.34 ms |       34.15 ms |       34.65 ms |       35.66 ms |   86.22% |      7.79 MiB |
-----------------------------------------------------------------------------------------------------------------------------------------
Benchmark Execution Parameters:
582b531 Thu, 23 Sep 2021 15:41:45 +0200 LesnyRumcajs remove vendor
- GRPC_BENCHMARK_DURATION=90s
- GRPC_BENCHMARK_WARMUP=15s
- GRPC_SERVER_CPUS=2
- GRPC_SERVER_RAM=512m
- GRPC_CLIENT_CONNECTIONS=50
- GRPC_CLIENT_CONCURRENCY=1000
- GRPC_CLIENT_QPS=0
- GRPC_CLIENT_CPUS=8
- GRPC_REQUEST_PAYLOAD=100B
```