### PR TITLE
Improve Elixir Performance

### DIFF
--- a/elixir_grpc_bench/Dockerfile
+++ b/elixir_grpc_bench/Dockerfile
@@ -15,4 +15,11 @@ RUN protoc --proto_path=/app/proto/helloworld --elixir_out=plugins=grpc:./lib/ h
 ENV MIX_ENV=prod
 RUN mix do deps.get, compile
 
-ENTRYPOINT [ "mix", "grpc.server" ]
+RUN echo "+sbwt none" >> /app/rel/vm.args.eex \
+    && echo "+sbwtdcpu none" >> /app/rel/vm.args.eex \
+    && echo "+sbwtdio none" >> /app/rel/vm.args.eex 
+
+RUN mix release.init \
+    && mix release
+
+CMD ["/app/_build/prod/rel/helloworld/bin/helloworld", "start"]

--- a/elixir_grpc_bench/config/config.exs
+++ b/elixir_grpc_bench/config/config.exs
@@ -1,4 +1,9 @@
 import Config
 
-# Start server in OTP
-# config :grpc, start_server: true
+config :grpc, start_server: true
+
+config :logger,
+  level: :error,
+  compile_time_purge_level: :error,
+  sync_threshold: 10_000,
+  truncate: 4096

--- a/elixir_grpc_bench/config/config.exs
+++ b/elixir_grpc_bench/config/config.exs
@@ -1,6 +1,4 @@
-use Mix.Config
+import Config
 
 # Start server in OTP
 # config :grpc, start_server: true
-
-import_config "#{Mix.env}.exs"

--- a/elixir_grpc_bench/config/dev.exs
+++ b/elixir_grpc_bench/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/elixir_grpc_bench/config/dev.exs
+++ b/elixir_grpc_bench/config/dev.exs
@@ -1,1 +1,9 @@
 import Config
+
+config :grpc, start_server: true
+
+config :logger,
+  level: :error,
+  compile_time_purge_level: :error,
+  sync_threshold: 10_000,
+  truncate: 4096

--- a/elixir_grpc_bench/config/prod.exs
+++ b/elixir_grpc_bench/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :grpc, start_server: true
 

--- a/elixir_grpc_bench/config/prod.exs
+++ b/elixir_grpc_bench/config/prod.exs
@@ -3,4 +3,7 @@ import Config
 config :grpc, start_server: true
 
 config :logger,
-  level: :error
+  level: :error,
+  compile_time_purge_level: :error,
+  sync_threshold: 10_000,
+  truncate: 4096

--- a/elixir_grpc_bench/lib/endpoint.ex
+++ b/elixir_grpc_bench/lib/endpoint.ex
@@ -1,6 +1,6 @@
 defmodule Helloworld.Endpoint do
   use GRPC.Endpoint
 
-  intercept GRPC.Logger.Server
-  run Helloworld.Greeter.Server
+  intercept(GRPC.Logger.Server)
+  run(Helloworld.Greeter.Server)
 end

--- a/elixir_grpc_bench/lib/helloworld_app.ex
+++ b/elixir_grpc_bench/lib/helloworld_app.ex
@@ -2,10 +2,9 @@ defmodule HelloworldApp do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     children = [
-      supervisor(GRPC.Server.Supervisor, [{Helloworld.Endpoint, 50051}])
+      {GRPC.Server.Supervisor,
+       {Helloworld.Endpoint, 50051, [num_acceptors: 1000, max_connections: 100_000]}}
     ]
 
     opts = [strategy: :one_for_one, name: HelloworldApp]

--- a/elixir_grpc_bench/mix.exs
+++ b/elixir_grpc_bench/mix.exs
@@ -20,7 +20,6 @@ defmodule Helloworld.Mixfile do
   defp deps do
     [
       {:grpc, github: "elixir-grpc/grpc"},
-      # {:grpc, github: "eigr-labs/grpc"},
       {:protobuf, "~> 0.9.0", override: true},
       {:cowlib, "~> 2.11", override: true},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}

--- a/elixir_grpc_bench/mix.exs
+++ b/elixir_grpc_bench/mix.exs
@@ -8,7 +8,8 @@ defmodule Helloworld.Mixfile do
       elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      releases: releases()
     ]
   end
 
@@ -19,9 +20,19 @@ defmodule Helloworld.Mixfile do
   defp deps do
     [
       {:grpc, github: "elixir-grpc/grpc"},
+      # {:grpc, github: "eigr-labs/grpc"},
       {:protobuf, "~> 0.9.0", override: true},
       {:cowlib, "~> 2.11", override: true},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}
+    ]
+  end
+
+  defp releases() do
+    [
+      helloworld: [
+        include_executables_for: [:unix],
+        applications: [runtime_tools: :permanent]
+      ]
     ]
   end
 end

--- a/elixir_grpc_bench/mix.exs
+++ b/elixir_grpc_bench/mix.exs
@@ -21,7 +21,6 @@ defmodule Helloworld.Mixfile do
       {:grpc, github: "elixir-grpc/grpc"},
       {:protobuf, github: "tony612/protobuf-elixir", override: true},
       {:cowlib, "~> 2.9", override: true},
-      {:ranch, "~> 2.1", override: true},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}
     ]
   end

--- a/elixir_grpc_bench/mix.exs
+++ b/elixir_grpc_bench/mix.exs
@@ -19,8 +19,8 @@ defmodule Helloworld.Mixfile do
   defp deps do
     [
       {:grpc, github: "elixir-grpc/grpc"},
-      {:protobuf, github: "tony612/protobuf-elixir", override: true},
-      {:cowlib, "~> 2.9", override: true},
+      {:protobuf, "~> 0.9.0", override: true},
+      {:cowlib, "~> 2.11", override: true},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}
     ]
   end

--- a/elixir_grpc_bench/mix.exs
+++ b/elixir_grpc_bench/mix.exs
@@ -2,25 +2,27 @@ defmodule Helloworld.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :helloworld,
-     version: "0.1.0",
-     elixir: "~> 1.4",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+    [
+      app: :helloworld,
+      version: "0.1.0",
+      elixir: "~> 1.13",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   def application do
-    [mod: {HelloworldApp, []},
-     applications: [:logger, :grpc]]
+    [mod: {HelloworldApp, []}, applications: [:logger, :grpc]]
   end
 
   defp deps do
     [
       {:grpc, github: "elixir-grpc/grpc"},
       {:protobuf, github: "tony612/protobuf-elixir", override: true},
-      {:cowlib, "~> 2.9.0", override: true},
-      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:cowlib, "~> 2.9", override: true},
+      {:ranch, "~> 2.1", override: true},
+      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}
     ]
   end
 end

--- a/elixir_grpc_bench/mix.lock
+++ b/elixir_grpc_bench/mix.lock
@@ -1,9 +1,9 @@
 %{
   "cowboy": {:hex, :cowboy, "2.9.0", "865dd8b6607e14cf03282e10e934023a1bd8be6f6bacf921a7e2a96d800cd452", [:make, :rebar3], [{:cowlib, "2.11.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "2c729f934b4e1aa149aff882f57c6372c15399a20d54f65c8d67bef583021bde"},
-  "cowlib": {:hex, :cowlib, "2.9.1", "61a6c7c50cf07fdd24b2f45b89500bb93b6686579b069a89f88cb211e1125c78", [:rebar3], [], "hexpm", "e4175dc240a70d996156160891e1c62238ede1729e45740bdd38064dad476170"},
+  "cowlib": {:hex, :cowlib, "2.11.0", "0b9ff9c346629256c42ebe1eeb769a83c6cb771a6ee5960bd110ab0b9b872063", [:make, :rebar3], [], "hexpm", "2b3e9da0b21c4565751a6d4901c20d1b4cc25cbb7fd50d91d2ab6dd287bc86a9"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm", "6c32a70ed5d452c6650916555b1f96c79af5fc4bf286997f8b15f213de786f73"},
   "grpc": {:git, "https://github.com/elixir-grpc/grpc.git", "eff8a8828d27ddd7f63a3c1dd5aae86246df215e", []},
   "gun": {:hex, :grpc_gun, "2.0.0", "f99678a2ab975e74372a756c86ec30a8384d3ac8a8b86c7ed6243ef4e61d2729", [:rebar3], [{:cowlib, "~> 2.8.0", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm", "03dbbca1a9c604a0267a40ea1d69986225091acb822de0b2dbea21d5815e410b"},
-  "protobuf": {:git, "https://github.com/tony612/protobuf-elixir.git", "bb8085047c5484358704b862cf6736cc41e2e404", []},
+  "protobuf": {:hex, :protobuf, "0.9.0", "9c1633ecc098f3d7ec0a00503e070541b0e1868114fff41523934888442319e7", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "15fb7cddc5f85b8055fedaf81a9093020e4cd283647a21deb8f7de8d243abb9d"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
 }

--- a/elixir_grpc_bench/mix.lock
+++ b/elixir_grpc_bench/mix.lock
@@ -1,0 +1,9 @@
+%{
+  "cowboy": {:hex, :cowboy, "2.9.0", "865dd8b6607e14cf03282e10e934023a1bd8be6f6bacf921a7e2a96d800cd452", [:make, :rebar3], [{:cowlib, "2.11.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "2c729f934b4e1aa149aff882f57c6372c15399a20d54f65c8d67bef583021bde"},
+  "cowlib": {:hex, :cowlib, "2.9.1", "61a6c7c50cf07fdd24b2f45b89500bb93b6686579b069a89f88cb211e1125c78", [:rebar3], [], "hexpm", "e4175dc240a70d996156160891e1c62238ede1729e45740bdd38064dad476170"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm", "6c32a70ed5d452c6650916555b1f96c79af5fc4bf286997f8b15f213de786f73"},
+  "grpc": {:git, "https://github.com/elixir-grpc/grpc.git", "eff8a8828d27ddd7f63a3c1dd5aae86246df215e", []},
+  "gun": {:hex, :grpc_gun, "2.0.0", "f99678a2ab975e74372a756c86ec30a8384d3ac8a8b86c7ed6243ef4e61d2729", [:rebar3], [{:cowlib, "~> 2.8.0", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm", "03dbbca1a9c604a0267a40ea1d69986225091acb822de0b2dbea21d5815e410b"},
+  "protobuf": {:git, "https://github.com/tony612/protobuf-elixir.git", "bb8085047c5484358704b862cf6736cc41e2e404", []},
+  "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
+}


### PR DESCRIPTION
This is the second PR I've submitted in an attempt to improve Elixir Benchmark's performance.

In my tests I saw a significant improvement in tests with different configurations. Especially when the level of concurrency on the server is increased. For example this is the result with 6 cpus available for the server and 2 for the client:

![master](https://user-images.githubusercontent.com/342502/148602560-60aa8d32-f3f0-423f-a7ca-34f7c3198a81.png)

This PR also improves overall performance, however due to the highly concurrent nature of the BEAM VM the performance is less impressive when using only 2 cpus for the server:

![2-cpus-ok](https://user-images.githubusercontent.com/342502/148602882-90a16edd-a9c1-46dd-8302-138afb685197.png)

