### PR TITLE
add go vitess proto benchmark

### DIFF
--- a/go_vtgrpc_bench/Dockerfile
+++ b/go_vtgrpc_bench/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.17
+
+WORKDIR /app
+COPY go_vtgrpc_bench /app
+COPY proto /app/proto
+
+ENV GOBIN /go/bin
+
+RUN apt update && apt install -y protobuf-compiler
+RUN go get google.golang.org/protobuf/cmd/protoc-gen-go
+RUN go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
+RUN go get github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto
+
+RUN protoc -I /app/proto/helloworld /app/proto/helloworld/helloworld.proto --go-grpc_out=/app/ --go_out=/app/ --go-vtproto_out=/app/ --plugin protoc-gen-go-vtproto="${GOBIN}/protoc-gen-go-vtproto" --go-vtproto_opt=features=marshal+unmarshal+size 
+RUN go mod tidy && go build ./... && go install ./...
+
+ENTRYPOINT example

--- a/go_vtgrpc_bench/example/main.go
+++ b/go_vtgrpc_bench/example/main.go
@@ -1,0 +1,60 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package main implements a server for Greeter service.
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+
+	"google.golang.org/grpc"
+	vtgrpc "github.com/planetscale/vtprotobuf/codec/grpc"
+	"google.golang.org/grpc/encoding"
+	_ "google.golang.org/grpc/encoding/proto"
+	pb "local/proto/helloworld"
+)
+
+const (
+	port = ":50051"
+)
+
+// server is used to implement helloworld.GreeterServer.
+type server struct {
+	pb.UnimplementedGreeterServer
+}
+
+// SayHello implements helloworld.GreeterServer
+func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+	return &pb.HelloReply{Response: in.GetRequest()}, nil
+}
+
+func main() {
+	lis, err := net.Listen("tcp", port)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	encoding.RegisterCodec(vtgrpc.Codec{})
+	s := grpc.NewServer()
+	pb.RegisterGreeterServer(s, &server{})
+	if err := s.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+
+}

--- a/go_vtgrpc_bench/go.mod
+++ b/go_vtgrpc_bench/go.mod
@@ -1,0 +1,12 @@
+module example
+
+go 1.17
+
+require (
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98
+	google.golang.org/grpc v1.36.0
+	google.golang.org/protobuf v1.27.1
+)
+
+replace local => ./


### PR DESCRIPTION
Adding another go benchmark with [vtprotobuf](https://github.com/planetscale/vtprotobuf).

This is the result you can expect:

- GRPC_BENCHMARK_DURATION=20s
- GRPC_BENCHMARK_WARMUP=5s
- GRPC_SERVER_CPUS=1
- GRPC_SERVER_RAM=512m
- GRPC_CLIENT_CONNECTIONS=50
- GRPC_CLIENT_CONCURRENCY=1000
- GRPC_CLIENT_QPS=0
- GRPC_CLIENT_CPUS=8
- GRPC_REQUEST_SCENARIO=complex_proto

1 CPU server:
| name                        |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
|--------------------|--------|--------------|-------------|-------------|-------------|---------|---------------|
| go_vtgrpc                   |   18549 |       49.59 ms |       93.72 ms |       98.05 ms |      109.40 ms |   75.44% |      28.1 MiB |
| go_grpc                     |   14011 |       67.50 ms |      103.22 ms |      115.62 ms |      197.30 ms |   75.69% |     29.47 MiB |

2 CPU server:
| name                        |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
|--------------------|-------|---------------|------------|--------------|------------|----------|---------------|
| go_vtgrpc                   |   41838 |       19.22 ms |       49.26 ms |       55.78 ms |       67.23 ms |  202.77% |     29.14 MiB |
| go_grpc                     |   32165 |       26.55 ms |       66.80 ms |       73.20 ms |       85.65 ms |  152.09% |      29.1 MiB |

3 CPU server:
| name                        |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
|--------------------|-------|---------------|-------------|-------------|-------------|---------|----------------|
| go_vtgrpc                   |   61568 |       11.37 ms |       21.22 ms |       25.77 ms |       36.78 ms |  200.87% |     27.54 MiB |
| go_grpc                     |   53127 |       14.10 ms |       28.20 ms |       34.84 ms |       48.38 ms |  307.54% |     30.51 MiB |