### PR TITLE
Add java quarkus native bench

### DIFF
--- a/java_quarkus_native_bench/Dockerfile
+++ b/java_quarkus_native_bench/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/graalvm/graalvm-ce:ol8-java11-21.1.0 as rel
+
+WORKDIR /app
+
+RUN gu install native-image
+
+COPY java_quarkus_bench /app
+COPY proto /app/src/main/proto
+
+RUN /app/mvnw clean package -Pnative
+
+# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+ENTRYPOINT /app/target/java_quarkus_bench-1.0.0-SNAPSHOT-runner -Dquarkus.grpc.server.instances="${GRPC_SERVER_CPUS:-1}"


### PR DESCRIPTION

| name                        |   req/s |   avg. latency |        90 % in |        95 % in |        99 % in | avg. cpu |   avg. memory |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| java_quarkus_native         |   15104 |       54.02 ms |       88.60 ms |      100.70 ms |      130.71 ms |   65.66% |     91.05 MiB |
| java_quarkus                |   14427 |       53.52 ms |       93.32 ms |      106.15 ms |      146.26 ms |   64.66% |     116.4 MiB |

Benchmark Execution Parameters:
- GRPC_BENCHMARK_DURATION=20s
- GRPC_BENCHMARK_WARMUP=5s
- GRPC_SERVER_CPUS=1
- GRPC_SERVER_RAM=512m
- GRPC_CLIENT_CONNECTIONS=50
- GRPC_CLIENT_CONCURRENCY=1000
- GRPC_CLIENT_QPS=0
- GRPC_CLIENT_CPUS=1
- GRPC_REQUEST_SCENARIO=complex_proto