### PR TITLE
Fix flaky build of some images.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/*_bench/Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
 
 env:
-  GRPC_IMAGE_NAME: localhost:5000/grpc_bench
   GRPC_REQUEST_SCENARIO: complex_proto
 
 jobs:
@@ -16,84 +15,27 @@ jobs:
     - run: ./generate_ci.sh | tee .github/workflows/build.yml
     - run: git --no-pager diff --exit-code
 
-  build-cpp_asio_grpc:
+  cpp_asio_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'cpp_asio_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:cpp_asio_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:cpp_asio_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:cpp_asio_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:cpp_asio_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build cpp_asio_grpc_bench
+    - name: Build cpp_asio_grpc_bench
       run: ./build.sh cpp_asio_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:cpp_asio_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-cpp_asio_grpc:
-    runs-on: ubuntu-latest
-    needs: build-cpp_asio_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'cpp_asio_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:cpp_asio_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark cpp_asio_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh cpp_asio_grpc_bench
+      run: ./bench.sh cpp_asio_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -105,91 +47,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:cpp_asio_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:cpp_asio_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:cpp_asio_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:cpp_asio_grpc_bench-complex_proto
 
-  build-cpp_grpc_mt:
+  cpp_grpc_mt_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'cpp_grpc_mt_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:cpp_grpc_mt_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:cpp_grpc_mt_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:cpp_grpc_mt_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:cpp_grpc_mt_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build cpp_grpc_mt_bench
+    - name: Build cpp_grpc_mt_bench
       run: ./build.sh cpp_grpc_mt_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:cpp_grpc_mt_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-cpp_grpc_mt:
-    runs-on: ubuntu-latest
-    needs: build-cpp_grpc_mt
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'cpp_grpc_mt_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:cpp_grpc_mt_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark cpp_grpc_mt_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh cpp_grpc_mt_bench
+      run: ./bench.sh cpp_grpc_mt_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -201,91 +81,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:cpp_grpc_mt_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:cpp_grpc_mt_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:cpp_grpc_mt_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:cpp_grpc_mt_bench-complex_proto
 
-  build-cpp_grpc_st:
+  cpp_grpc_st_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'cpp_grpc_st_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:cpp_grpc_st_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:cpp_grpc_st_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:cpp_grpc_st_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:cpp_grpc_st_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build cpp_grpc_st_bench
+    - name: Build cpp_grpc_st_bench
       run: ./build.sh cpp_grpc_st_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:cpp_grpc_st_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-cpp_grpc_st:
-    runs-on: ubuntu-latest
-    needs: build-cpp_grpc_st
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'cpp_grpc_st_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:cpp_grpc_st_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark cpp_grpc_st_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh cpp_grpc_st_bench
+      run: ./bench.sh cpp_grpc_st_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -297,91 +115,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:cpp_grpc_st_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:cpp_grpc_st_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:cpp_grpc_st_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:cpp_grpc_st_bench-complex_proto
 
-  build-crystal_grpc:
+  crystal_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'crystal_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:crystal_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:crystal_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:crystal_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:crystal_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build crystal_grpc_bench
+    - name: Build crystal_grpc_bench
       run: ./build.sh crystal_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:crystal_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-crystal_grpc:
-    runs-on: ubuntu-latest
-    needs: build-crystal_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'crystal_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:crystal_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark crystal_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh crystal_grpc_bench
+      run: ./bench.sh crystal_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -393,91 +149,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:crystal_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:crystal_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:crystal_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:crystal_grpc_bench-complex_proto
 
-  build-csharp_grpc:
+  csharp_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'csharp_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:csharp_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:csharp_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:csharp_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:csharp_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build csharp_grpc_bench
+    - name: Build csharp_grpc_bench
       run: ./build.sh csharp_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:csharp_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-csharp_grpc:
-    runs-on: ubuntu-latest
-    needs: build-csharp_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'csharp_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:csharp_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark csharp_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh csharp_grpc_bench
+      run: ./bench.sh csharp_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -489,91 +183,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:csharp_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:csharp_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:csharp_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:csharp_grpc_bench-complex_proto
 
-  build-dotnet_grpc:
+  dotnet_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'dotnet_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:dotnet_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:dotnet_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:dotnet_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:dotnet_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build dotnet_grpc_bench
+    - name: Build dotnet_grpc_bench
       run: ./build.sh dotnet_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:dotnet_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-dotnet_grpc:
-    runs-on: ubuntu-latest
-    needs: build-dotnet_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'dotnet_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:dotnet_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark dotnet_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh dotnet_grpc_bench
+      run: ./bench.sh dotnet_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -585,91 +217,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:dotnet_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:dotnet_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:dotnet_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:dotnet_grpc_bench-complex_proto
 
-  build-elixir_grpc:
+  elixir_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'elixir_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:elixir_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:elixir_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:elixir_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:elixir_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build elixir_grpc_bench
+    - name: Build elixir_grpc_bench
       run: ./build.sh elixir_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:elixir_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-elixir_grpc:
-    runs-on: ubuntu-latest
-    needs: build-elixir_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'elixir_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:elixir_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark elixir_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh elixir_grpc_bench
+      run: ./bench.sh elixir_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -681,91 +251,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:elixir_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:elixir_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:elixir_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:elixir_grpc_bench-complex_proto
 
-  build-erlang_grpcbox:
+  erlang_grpcbox_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'erlang_grpcbox_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:erlang_grpcbox_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:erlang_grpcbox_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:erlang_grpcbox_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:erlang_grpcbox_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build erlang_grpcbox_bench
+    - name: Build erlang_grpcbox_bench
       run: ./build.sh erlang_grpcbox_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:erlang_grpcbox_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-erlang_grpcbox:
-    runs-on: ubuntu-latest
-    needs: build-erlang_grpcbox
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'erlang_grpcbox_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:erlang_grpcbox_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark erlang_grpcbox_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh erlang_grpcbox_bench
+      run: ./bench.sh erlang_grpcbox_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -777,91 +285,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:erlang_grpcbox_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:erlang_grpcbox_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:erlang_grpcbox_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:erlang_grpcbox_bench-complex_proto
 
-  build-go_grpc:
+  go_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'go_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:go_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:go_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:go_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:go_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build go_grpc_bench
+    - name: Build go_grpc_bench
       run: ./build.sh go_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:go_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-go_grpc:
-    runs-on: ubuntu-latest
-    needs: build-go_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'go_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:go_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark go_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh go_grpc_bench
+      run: ./bench.sh go_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -873,91 +319,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:go_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:go_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:go_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:go_grpc_bench-complex_proto
 
-  build-go_vtgrpc:
+  go_vtgrpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'go_vtgrpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:go_vtgrpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:go_vtgrpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:go_vtgrpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:go_vtgrpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build go_vtgrpc_bench
+    - name: Build go_vtgrpc_bench
       run: ./build.sh go_vtgrpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:go_vtgrpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-go_vtgrpc:
-    runs-on: ubuntu-latest
-    needs: build-go_vtgrpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'go_vtgrpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:go_vtgrpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark go_vtgrpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh go_vtgrpc_bench
+      run: ./bench.sh go_vtgrpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -969,91 +353,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:go_vtgrpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:go_vtgrpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:go_vtgrpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:go_vtgrpc_bench-complex_proto
 
-  build-java_aot:
+  java_aot_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_aot_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_aot_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_aot_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_aot_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_aot_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_aot_bench
+    - name: Build java_aot_bench
       run: ./build.sh java_aot_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_aot_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_aot:
-    runs-on: ubuntu-latest
-    needs: build-java_aot
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_aot_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_aot_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_aot_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_aot_bench
+      run: ./bench.sh java_aot_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1065,91 +387,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_aot_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_aot_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_aot_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_aot_bench-complex_proto
 
-  build-java_hotspot_grpc_g1gc:
+  java_hotspot_grpc_g1gc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_g1gc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_hotspot_grpc_g1gc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_hotspot_grpc_g1gc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_hotspot_grpc_g1gc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_g1gc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_hotspot_grpc_g1gc_bench
+    - name: Build java_hotspot_grpc_g1gc_bench
       run: ./build.sh java_hotspot_grpc_g1gc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_g1gc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_hotspot_grpc_g1gc:
-    runs-on: ubuntu-latest
-    needs: build-java_hotspot_grpc_g1gc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_g1gc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_hotspot_grpc_g1gc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_hotspot_grpc_g1gc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_hotspot_grpc_g1gc_bench
+      run: ./bench.sh java_hotspot_grpc_g1gc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1161,91 +421,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_hotspot_grpc_g1gc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_hotspot_grpc_g1gc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_hotspot_grpc_g1gc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_g1gc_bench-complex_proto
 
-  build-java_hotspot_grpc_pgc:
+  java_hotspot_grpc_pgc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_pgc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_hotspot_grpc_pgc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_hotspot_grpc_pgc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_hotspot_grpc_pgc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_pgc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_hotspot_grpc_pgc_bench
+    - name: Build java_hotspot_grpc_pgc_bench
       run: ./build.sh java_hotspot_grpc_pgc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_pgc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_hotspot_grpc_pgc:
-    runs-on: ubuntu-latest
-    needs: build-java_hotspot_grpc_pgc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_pgc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_hotspot_grpc_pgc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_hotspot_grpc_pgc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_hotspot_grpc_pgc_bench
+      run: ./bench.sh java_hotspot_grpc_pgc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1257,91 +455,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_hotspot_grpc_pgc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_hotspot_grpc_pgc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_hotspot_grpc_pgc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_pgc_bench-complex_proto
 
-  build-java_hotspot_grpc_sgc:
+  java_hotspot_grpc_sgc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_sgc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_hotspot_grpc_sgc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_hotspot_grpc_sgc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_hotspot_grpc_sgc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_sgc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_hotspot_grpc_sgc_bench
+    - name: Build java_hotspot_grpc_sgc_bench
       run: ./build.sh java_hotspot_grpc_sgc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_sgc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_hotspot_grpc_sgc:
-    runs-on: ubuntu-latest
-    needs: build-java_hotspot_grpc_sgc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_sgc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_hotspot_grpc_sgc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_hotspot_grpc_sgc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_hotspot_grpc_sgc_bench
+      run: ./bench.sh java_hotspot_grpc_sgc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1353,91 +489,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_hotspot_grpc_sgc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_hotspot_grpc_sgc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_hotspot_grpc_sgc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_sgc_bench-complex_proto
 
-  build-java_hotspot_grpc_she:
+  java_hotspot_grpc_she_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_she_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_hotspot_grpc_she_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_hotspot_grpc_she_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_hotspot_grpc_she_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_she_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_hotspot_grpc_she_bench
+    - name: Build java_hotspot_grpc_she_bench
       run: ./build.sh java_hotspot_grpc_she_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_she_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_hotspot_grpc_she:
-    runs-on: ubuntu-latest
-    needs: build-java_hotspot_grpc_she
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_she_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_hotspot_grpc_she_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_hotspot_grpc_she_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_hotspot_grpc_she_bench
+      run: ./bench.sh java_hotspot_grpc_she_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1449,91 +523,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_hotspot_grpc_she_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_hotspot_grpc_she_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_hotspot_grpc_she_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_she_bench-complex_proto
 
-  build-java_hotspot_grpc_zgc:
+  java_hotspot_grpc_zgc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_zgc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_hotspot_grpc_zgc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_hotspot_grpc_zgc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_hotspot_grpc_zgc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_zgc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_hotspot_grpc_zgc_bench
+    - name: Build java_hotspot_grpc_zgc_bench
       run: ./build.sh java_hotspot_grpc_zgc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_zgc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_hotspot_grpc_zgc:
-    runs-on: ubuntu-latest
-    needs: build-java_hotspot_grpc_zgc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_hotspot_grpc_zgc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_hotspot_grpc_zgc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_hotspot_grpc_zgc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_hotspot_grpc_zgc_bench
+      run: ./bench.sh java_hotspot_grpc_zgc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1545,91 +557,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_hotspot_grpc_zgc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_hotspot_grpc_zgc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_hotspot_grpc_zgc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_hotspot_grpc_zgc_bench-complex_proto
 
-  build-java_micronaut:
+  java_micronaut_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_micronaut_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_micronaut_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_micronaut_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_micronaut_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_micronaut_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_micronaut_bench
+    - name: Build java_micronaut_bench
       run: ./build.sh java_micronaut_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_micronaut_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_micronaut:
-    runs-on: ubuntu-latest
-    needs: build-java_micronaut
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_micronaut_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_micronaut_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_micronaut_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_micronaut_bench
+      run: ./bench.sh java_micronaut_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1641,91 +591,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_micronaut_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_micronaut_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_micronaut_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_micronaut_bench-complex_proto
 
-  build-java_micronaut_workstealing:
+  java_micronaut_workstealing_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_micronaut_workstealing_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_micronaut_workstealing_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_micronaut_workstealing_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_micronaut_workstealing_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_micronaut_workstealing_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_micronaut_workstealing_bench
+    - name: Build java_micronaut_workstealing_bench
       run: ./build.sh java_micronaut_workstealing_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_micronaut_workstealing_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_micronaut_workstealing:
-    runs-on: ubuntu-latest
-    needs: build-java_micronaut_workstealing
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_micronaut_workstealing_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_micronaut_workstealing_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_micronaut_workstealing_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_micronaut_workstealing_bench
+      run: ./bench.sh java_micronaut_workstealing_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1737,91 +625,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_micronaut_workstealing_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_micronaut_workstealing_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_micronaut_workstealing_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_micronaut_workstealing_bench-complex_proto
 
-  build-java_openj9_grpc_gencon:
+  java_openj9_grpc_gencon_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_openj9_grpc_gencon_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_openj9_grpc_gencon_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_openj9_grpc_gencon_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_openj9_grpc_gencon_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_openj9_grpc_gencon_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_openj9_grpc_gencon_bench
+    - name: Build java_openj9_grpc_gencon_bench
       run: ./build.sh java_openj9_grpc_gencon_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_openj9_grpc_gencon_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_openj9_grpc_gencon:
-    runs-on: ubuntu-latest
-    needs: build-java_openj9_grpc_gencon
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_openj9_grpc_gencon_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_openj9_grpc_gencon_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_openj9_grpc_gencon_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_openj9_grpc_gencon_bench
+      run: ./bench.sh java_openj9_grpc_gencon_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1833,91 +659,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_openj9_grpc_gencon_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_openj9_grpc_gencon_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_openj9_grpc_gencon_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_openj9_grpc_gencon_bench-complex_proto
 
-  build-java_quarkus:
+  java_quarkus_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_quarkus_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_quarkus_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_quarkus_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_quarkus_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_quarkus_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_quarkus_bench
+    - name: Build java_quarkus_bench
       run: ./build.sh java_quarkus_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_quarkus_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_quarkus:
-    runs-on: ubuntu-latest
-    needs: build-java_quarkus
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_quarkus_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_quarkus_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_quarkus_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_quarkus_bench
+      run: ./bench.sh java_quarkus_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -1929,91 +693,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_quarkus_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_quarkus_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_quarkus_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_quarkus_bench-complex_proto
 
-  build-java_quarkus_native:
+  java_quarkus_native_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_quarkus_native_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:java_quarkus_native_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:java_quarkus_native_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:java_quarkus_native_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:java_quarkus_native_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build java_quarkus_native_bench
+    - name: Build java_quarkus_native_bench
       run: ./build.sh java_quarkus_native_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:java_quarkus_native_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-java_quarkus_native:
-    runs-on: ubuntu-latest
-    needs: build-java_quarkus_native
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'java_quarkus_native_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:java_quarkus_native_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark java_quarkus_native_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh java_quarkus_native_bench
+      run: ./bench.sh java_quarkus_native_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2025,91 +727,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:java_quarkus_native_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:java_quarkus_native_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:java_quarkus_native_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:java_quarkus_native_bench-complex_proto
 
-  build-kotlin_grpc:
+  kotlin_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'kotlin_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:kotlin_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:kotlin_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:kotlin_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:kotlin_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build kotlin_grpc_bench
+    - name: Build kotlin_grpc_bench
       run: ./build.sh kotlin_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:kotlin_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-kotlin_grpc:
-    runs-on: ubuntu-latest
-    needs: build-kotlin_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'kotlin_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:kotlin_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark kotlin_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh kotlin_grpc_bench
+      run: ./bench.sh kotlin_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2121,91 +761,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:kotlin_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:kotlin_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:kotlin_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:kotlin_grpc_bench-complex_proto
 
-  build-node_grpcjs_st:
+  node_grpcjs_st_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'node_grpcjs_st_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:node_grpcjs_st_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:node_grpcjs_st_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:node_grpcjs_st_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:node_grpcjs_st_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build node_grpcjs_st_bench
+    - name: Build node_grpcjs_st_bench
       run: ./build.sh node_grpcjs_st_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:node_grpcjs_st_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-node_grpcjs_st:
-    runs-on: ubuntu-latest
-    needs: build-node_grpcjs_st
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'node_grpcjs_st_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:node_grpcjs_st_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark node_grpcjs_st_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh node_grpcjs_st_bench
+      run: ./bench.sh node_grpcjs_st_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2217,91 +795,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:node_grpcjs_st_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:node_grpcjs_st_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:node_grpcjs_st_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:node_grpcjs_st_bench-complex_proto
 
-  build-php_grpc:
+  php_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'php_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:php_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:php_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:php_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:php_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build php_grpc_bench
+    - name: Build php_grpc_bench
       run: ./build.sh php_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:php_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-php_grpc:
-    runs-on: ubuntu-latest
-    needs: build-php_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'php_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:php_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark php_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh php_grpc_bench
+      run: ./bench.sh php_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2313,91 +829,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:php_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:php_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:php_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:php_grpc_bench-complex_proto
 
-  build-python_async_grpc:
+  python_async_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'python_async_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:python_async_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:python_async_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:python_async_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:python_async_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build python_async_grpc_bench
+    - name: Build python_async_grpc_bench
       run: ./build.sh python_async_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:python_async_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-python_async_grpc:
-    runs-on: ubuntu-latest
-    needs: build-python_async_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'python_async_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:python_async_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark python_async_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh python_async_grpc_bench
+      run: ./bench.sh python_async_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2409,91 +863,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:python_async_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:python_async_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:python_async_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:python_async_grpc_bench-complex_proto
 
-  build-python_grpc:
+  python_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'python_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:python_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:python_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:python_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:python_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build python_grpc_bench
+    - name: Build python_grpc_bench
       run: ./build.sh python_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:python_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-python_grpc:
-    runs-on: ubuntu-latest
-    needs: build-python_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'python_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:python_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark python_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh python_grpc_bench
+      run: ./bench.sh python_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2505,91 +897,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:python_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:python_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:python_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:python_grpc_bench-complex_proto
 
-  build-ruby_grpc:
+  ruby_grpc_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'ruby_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:ruby_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:ruby_grpc_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:ruby_grpc_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:ruby_grpc_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build ruby_grpc_bench
+    - name: Build ruby_grpc_bench
       run: ./build.sh ruby_grpc_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:ruby_grpc_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-ruby_grpc:
-    runs-on: ubuntu-latest
-    needs: build-ruby_grpc
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'ruby_grpc_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:ruby_grpc_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark ruby_grpc_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh ruby_grpc_bench
+      run: ./bench.sh ruby_grpc_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2601,91 +931,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:ruby_grpc_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:ruby_grpc_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:ruby_grpc_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:ruby_grpc_bench-complex_proto
 
-  build-rust_grpcio:
+  rust_grpcio_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_grpcio_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:rust_grpcio_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:rust_grpcio_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:rust_grpcio_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:rust_grpcio_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build rust_grpcio_bench
+    - name: Build rust_grpcio_bench
       run: ./build.sh rust_grpcio_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:rust_grpcio_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-rust_grpcio:
-    runs-on: ubuntu-latest
-    needs: build-rust_grpcio
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_grpcio_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:rust_grpcio_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark rust_grpcio_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh rust_grpcio_bench
+      run: ./bench.sh rust_grpcio_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2697,91 +965,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:rust_grpcio_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:rust_grpcio_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:rust_grpcio_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:rust_grpcio_bench-complex_proto
 
-  build-rust_thruster_mt:
+  rust_thruster_mt_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_thruster_mt_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:rust_thruster_mt_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:rust_thruster_mt_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:rust_thruster_mt_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:rust_thruster_mt_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build rust_thruster_mt_bench
+    - name: Build rust_thruster_mt_bench
       run: ./build.sh rust_thruster_mt_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:rust_thruster_mt_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-rust_thruster_mt:
-    runs-on: ubuntu-latest
-    needs: build-rust_thruster_mt
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_thruster_mt_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:rust_thruster_mt_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark rust_thruster_mt_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh rust_thruster_mt_bench
+      run: ./bench.sh rust_thruster_mt_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2793,91 +999,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:rust_thruster_mt_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:rust_thruster_mt_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:rust_thruster_mt_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:rust_thruster_mt_bench-complex_proto
 
-  build-rust_thruster_st:
+  rust_thruster_st_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_thruster_st_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:rust_thruster_st_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:rust_thruster_st_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:rust_thruster_st_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:rust_thruster_st_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build rust_thruster_st_bench
+    - name: Build rust_thruster_st_bench
       run: ./build.sh rust_thruster_st_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:rust_thruster_st_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-rust_thruster_st:
-    runs-on: ubuntu-latest
-    needs: build-rust_thruster_st
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_thruster_st_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:rust_thruster_st_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark rust_thruster_st_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh rust_thruster_st_bench
+      run: ./bench.sh rust_thruster_st_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2889,91 +1033,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:rust_thruster_st_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:rust_thruster_st_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:rust_thruster_st_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:rust_thruster_st_bench-complex_proto
 
-  build-rust_tonic_mt:
+  rust_tonic_mt_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_tonic_mt_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:rust_tonic_mt_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:rust_tonic_mt_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:rust_tonic_mt_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:rust_tonic_mt_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build rust_tonic_mt_bench
+    - name: Build rust_tonic_mt_bench
       run: ./build.sh rust_tonic_mt_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:rust_tonic_mt_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-rust_tonic_mt:
-    runs-on: ubuntu-latest
-    needs: build-rust_tonic_mt
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_tonic_mt_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:rust_tonic_mt_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark rust_tonic_mt_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh rust_tonic_mt_bench
+      run: ./bench.sh rust_tonic_mt_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -2985,91 +1067,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:rust_tonic_mt_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:rust_tonic_mt_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:rust_tonic_mt_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:rust_tonic_mt_bench-complex_proto
 
-  build-rust_tonic_st:
+  rust_tonic_st_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_tonic_st_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:rust_tonic_st_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:rust_tonic_st_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:rust_tonic_st_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:rust_tonic_st_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build rust_tonic_st_bench
+    - name: Build rust_tonic_st_bench
       run: ./build.sh rust_tonic_st_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:rust_tonic_st_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-rust_tonic_st:
-    runs-on: ubuntu-latest
-    needs: build-rust_tonic_st
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'rust_tonic_st_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:rust_tonic_st_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark rust_tonic_st_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh rust_tonic_st_bench
+      run: ./bench.sh rust_tonic_st_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -3081,91 +1101,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:rust_tonic_st_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:rust_tonic_st_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:rust_tonic_st_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:rust_tonic_st_bench-complex_proto
 
-  build-scala_akka:
+  scala_akka_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'scala_akka_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:scala_akka_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:scala_akka_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:scala_akka_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:scala_akka_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build scala_akka_bench
+    - name: Build scala_akka_bench
       run: ./build.sh scala_akka_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:scala_akka_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-scala_akka:
-    runs-on: ubuntu-latest
-    needs: build-scala_akka
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'scala_akka_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:scala_akka_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark scala_akka_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh scala_akka_bench
+      run: ./bench.sh scala_akka_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -3177,91 +1135,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:scala_akka_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:scala_akka_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:scala_akka_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:scala_akka_bench-complex_proto
 
-  build-scala_fs2:
+  scala_fs2_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'scala_fs2_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:scala_fs2_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:scala_fs2_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:scala_fs2_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:scala_fs2_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build scala_fs2_bench
+    - name: Build scala_fs2_bench
       run: ./build.sh scala_fs2_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:scala_fs2_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-scala_fs2:
-    runs-on: ubuntu-latest
-    needs: build-scala_fs2
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'scala_fs2_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:scala_fs2_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark scala_fs2_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh scala_fs2_bench
+      run: ./bench.sh scala_fs2_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -3273,91 +1169,29 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:scala_fs2_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:scala_fs2_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:scala_fs2_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:scala_fs2_bench-complex_proto
 
-  build-scala_zio:
+  scala_zio_bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'scala_zio_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/$SLUG:scala_zio_bench-$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/$SLUG:scala_zio_bench-$GRPC_REQUEST_SCENARIO $GRPC_IMAGE_NAME:scala_zio_bench-$GRPC_REQUEST_SCENARIO || true
-        docker push $GRPC_IMAGE_NAME:scala_zio_bench-$GRPC_REQUEST_SCENARIO || true
+        SLUG=${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/$SLUG" >>$GITHUB_ENV
       env:
         SLUG: ${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build scala_zio_bench
+    - name: Build scala_zio_bench
       run: ./build.sh scala_zio_bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push $GRPC_IMAGE_NAME:scala_zio_bench-$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-  bench-scala_zio:
-    runs-on: ubuntu-latest
-    needs: build-scala_zio
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-${{ hashFiles('proto/', 'scala_zio_bench/') }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull $GRPC_IMAGE_NAME:scala_zio_bench-$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark scala_zio_bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh scala_zio_bench
+      run: ./bench.sh scala_zio_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -3369,10 +1203,5 @@ jobs:
 
     - if: ${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=${SLUG,,} # Make sure docker tag is lowercase
-        docker tag $GRPC_IMAGE_NAME:scala_zio_bench-$GRPC_REQUEST_SCENARIO ghcr.io/$SLUG:scala_zio_bench-$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/$SLUG:scala_zio_bench-$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: ${{ github.repository }}
+      run: docker push $GRPC_IMAGE_NAME:scala_zio_bench-complex_proto
 

--- a/bench.sh
+++ b/bench.sh
@@ -29,7 +29,7 @@ export GRPC_IMAGE_NAME="${GRPC_IMAGE_NAME:-grpc_bench}"
 # export GRPC_CLIENT_QPS
 
 wait_on_tcp50051() {
-	for ((i=1;i<=10*5*60;i++)); do
+	for ((i=1;i<=10*30;i++)); do
 		nc -z localhost 50051 && return 0
 		sleep .1
 	done

--- a/generate_ci.sh
+++ b/generate_ci.sh
@@ -12,7 +12,6 @@ on:
   pull_request:
 
 env:
-  GRPC_IMAGE_NAME: localhost:5000/grpc_bench
   GRPC_REQUEST_SCENARIO: $GRPC_REQUEST_SCENARIO
 
 jobs:
@@ -25,98 +24,31 @@ jobs:
 
 EOF
 
-setup() {
-    local bench="$1"; shift
-    cat <<EOF
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup local registry cache
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: /tmp/docker-registry
-        key: docker-registry-\${{ hashFiles('proto/', '$bench/') }}
-
-EOF
-}
-
 while read -r bench; do
     bench=${bench##./}
 
-    # Build & cache branch-specific image for scenario
-
     cat <<EOF
-  build-${bench//_bench}:
+  $bench:
     runs-on: ubuntu-latest
     needs: meta-check
     steps:
-EOF
-    setup "$bench"
-    # On cache hit: do nothing. Improve with: https://github.com/actions/runner/issues/662
-    cat <<EOF
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
+    - name: Checkout
+      uses: actions/checkout@v2
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Log in to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: \${{ github.actor }}
-        password: \${{ secrets.GITHUB_TOKEN }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Pull image to feed cache
+    - name: Set GRPC_IMAGE_NAME
       run: |
-        SLUG=\${SLUG,,} # Make sure docker tag is lowercase
-        docker pull    ghcr.io/\$SLUG:$bench-\$GRPC_REQUEST_SCENARIO || true
-        docker tag     ghcr.io/\$SLUG:$bench-\$GRPC_REQUEST_SCENARIO \$GRPC_IMAGE_NAME:$bench-\$GRPC_REQUEST_SCENARIO || true
-        docker push \$GRPC_IMAGE_NAME:$bench-\$GRPC_REQUEST_SCENARIO || true
+        SLUG=\${SLUG,,} # Lowercase
+        echo "GRPC_IMAGE_NAME=ghcr.io/\$SLUG" >>\$GITHUB_ENV
       env:
         SLUG: \${{ github.repository }}
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Build $bench
+    - name: Build $bench
       run: ./build.sh $bench
 
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Ensure local registry has most recent image
-      run: |
-        docker push \$GRPC_IMAGE_NAME:$bench-\$GRPC_REQUEST_SCENARIO
-        du -sh /tmp/docker-registry
-
-
-EOF
-
-    # Benchmark branch-specific image for scenario
-
-    cat <<EOF
-  bench-${bench//_bench}:
-    runs-on: ubuntu-latest
-    needs: build-${bench//_bench}
-    steps:
-EOF
-    setup "$bench"
-    cat <<EOF
-    - if: steps.cache.outputs.cache-hit != 'true'
-      name: Fail job on cache miss
-      run: 'false'
-
-    - name: Setup local Docker registry
-      run: |
-        docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-        while ! nc -z localhost 5000; do sleep .1; done
-
-    - name: Pull image from local registry
-      run: docker pull \$GRPC_IMAGE_NAME:$bench-\$GRPC_REQUEST_SCENARIO
-      timeout-minutes: 2
-
     - name: Benchmark $bench
-      run: GRPC_BENCHMARK_DURATION=30s ./bench.sh $bench
+      run: ./bench.sh $bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
 
     - if: \${{ github.ref == 'refs/heads/master' }}
       name: Log in to GitHub Container Registry
@@ -128,12 +60,7 @@ EOF
 
     - if: \${{ github.ref == 'refs/heads/master' }}
       name: If on master push image to GHCR
-      run: |
-        SLUG=\${SLUG,,} # Make sure docker tag is lowercase
-        docker tag \$GRPC_IMAGE_NAME:$bench-\$GRPC_REQUEST_SCENARIO ghcr.io/\$SLUG:$bench-\$GRPC_REQUEST_SCENARIO
-        docker push   ghcr.io/\$SLUG:$bench-\$GRPC_REQUEST_SCENARIO
-      env:
-        SLUG: \${{ github.repository }}
+      run: docker push \$GRPC_IMAGE_NAME:$bench-$GRPC_REQUEST_SCENARIO
 
 EOF
 

--- a/rust_grpcio_bench/Dockerfile
+++ b/rust_grpcio_bench/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /app
 COPY rust_grpcio_bench /app
 COPY proto /app/src/proto
 
-RUN cargo build --release
+RUN cargo build --release --locked
 
-ENTRYPOINT cargo run --release
+ENTRYPOINT ["/app/target/release/helloworld-server"]

--- a/rust_thruster_mt_bench/Dockerfile
+++ b/rust_thruster_mt_bench/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /app
 COPY rust_thruster_mt_bench /app
 COPY proto /app/proto
 
-RUN cat Cargo.toml
-RUN cargo build --release
-RUN cargo build --release
+RUN cargo build --release --locked
 
-ENTRYPOINT cargo run --release
+ENTRYPOINT ["/app/target/release/helloworld-server"]

--- a/rust_thruster_st_bench/Dockerfile
+++ b/rust_thruster_st_bench/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 COPY rust_thruster_st_bench /app
 COPY proto /app/proto
 
-RUN cargo build --release
-RUN cargo build --release
+RUN cargo build --release --locked
 
-ENTRYPOINT cargo run --release
+ENTRYPOINT ["/app/target/release/helloworld-server"]

--- a/rust_tonic_mt_bench/Dockerfile
+++ b/rust_tonic_mt_bench/Dockerfile
@@ -5,7 +5,6 @@ COPY rust_tonic_mt_bench /app
 COPY proto /app/proto
 
 RUN rustup component add rustfmt
-RUN cargo build --release
-RUN cargo build --release
+RUN cargo build --release --locked
 
-ENTRYPOINT cargo run --release
+ENTRYPOINT ["/app/target/release/helloworld-server"]

--- a/rust_tonic_st_bench/Dockerfile
+++ b/rust_tonic_st_bench/Dockerfile
@@ -5,6 +5,6 @@ COPY rust_tonic_st_bench /app
 COPY proto /app/proto
 
 RUN rustup component add rustfmt
-RUN cargo build --release
+RUN cargo build --release --locked
 
-ENTRYPOINT cargo run --release
+ENTRYPOINT ["/app/target/release/helloworld-server"]


### PR DESCRIPTION
Some Rust build & benchmark jobs failed sometimes. I root-caused that to using
arch=native compilation flags and at the same time encountering the off-chance
of getting a bench job scheduled on a machine with a hardware architecture
different enough from the one machine that ran the build job.

This patch merges these two jobs into one and drops github actions caching.
Building images still do rely on the --cache-from=IMG instruction anyways.

This also:
* excludes all dockerfiles from the image build context. Makes better use of
  cache when iterating on a Dockerfile
* shortens `wait_on_tcp50051`'s timeout from 5min to 30s to detect failures faster.
  I don't see what image would need more than 30s to start up.
* tidies up Rust dockerfiles (remove duplicate/debug lines, freeze lockfile)

Signed-off-by: Pierre Fenoll <pierrefenoll@gmail.com>