### PR TITLE
ghz: use image from official repo

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -75,7 +75,7 @@ for benchmark in ${BENCHMARKS_TO_RUN}; do
     	docker run --name ghz --rm --network=host -v "${PWD}/proto:/proto:ro" \
     	    -v "${PWD}/payload:/payload:ro" \
     		--cpus $GRPC_CLIENT_CPUS \
-    		obvionaoe/ghz \
+    		ghcr.io/bojand/ghz \
     		--proto=/proto/helloworld/helloworld.proto \
     		--call=helloworld.Greeter.SayHello \
             --insecure \
@@ -101,7 +101,7 @@ for benchmark in ${BENCHMARKS_TO_RUN}; do
 	docker run --name ghz --rm --network=host -v "${PWD}/proto:/proto:ro" \
 	    -v "${PWD}/payload:/payload:ro" \
 		--cpus $GRPC_CLIENT_CPUS \
-		obvionaoe/ghz \
+		ghcr.io/bojand/ghz \
 		--proto=/proto/helloworld/helloworld.proto \
 		--call=helloworld.Greeter.SayHello \
         --insecure \


### PR DESCRIPTION
This replaces the community-supported image I introduced earlier while refactoring CI.
Since then I developed the "official" ghz image and that PR got merged recently, so am replacing grpc_bench's ghz usage with it.