### PR TITLE
fix dependabot alert

### DIFF
--- a/node_grpcjs_st_bench/package.json
+++ b/node_grpcjs_st_bench/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "dependencies": {
       "@grpc/proto-loader": "^0.1.0",
-      "async": "^1.5.2",
+      "async": ">=2.6.4",
       "google-protobuf": "^3.0.0",
       "@grpc/grpc-js": "^1.4.4",
       "lodash": "^4.6.1",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fix dependabot alert



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
> A vulnerability exists in Async through 3.2.1 for 3.x and through 2.6.3 for 2.x (fixed in 3.2.2 and 2.6.4), which could let a malicious user obtain privileges via the mapValues() method.

<!-- Thank you 🔥 -->
