### PR TITLE
add gRPC-haskell benchmark

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,6 +420,42 @@ jobs:
         GRPC_IMAGE_NAME: ${{ needs.set-image-name.outputs.name }}
 
 
+  haskell_grpc_haskell_bench:
+    runs-on: ubuntu-latest
+    needs:
+    - set-image-name
+    - changed
+    if: fromJSON(needs.changed.outputs.base) || contains(needs.changed.outputs.files, 'haskell_grpc_haskell_bench/')
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build haskell_grpc_haskell_bench
+      run: ./build.sh haskell_grpc_haskell_bench
+      env:
+        GRPC_IMAGE_NAME: ${{ needs.set-image-name.outputs.name }}
+
+    - name: Benchmark haskell_grpc_haskell_bench
+      run: ./bench.sh haskell_grpc_haskell_bench
+      env:
+        GRPC_BENCHMARK_DURATION: 30s
+        GRPC_IMAGE_NAME: ${{ needs.set-image-name.outputs.name }}
+
+    - if: github.ref == 'refs/heads/master'
+      name: Log in to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - if: github.ref == 'refs/heads/master'
+      name: If on master push image to GHCR
+      run: docker push $GRPC_IMAGE_NAME:haskell_grpc_haskell_bench-complex_proto
+      env:
+        GRPC_IMAGE_NAME: ${{ needs.set-image-name.outputs.name }}
+
+
   java_aot_bench:
     runs-on: ubuntu-latest
     needs:

--- a/haskell_grpc_haskell_bench/.gitignore
+++ b/haskell_grpc_haskell_bench/.gitignore
@@ -1,0 +1,2 @@
+dist-newstyle
+src-gen/

--- a/haskell_grpc_haskell_bench/Dockerfile
+++ b/haskell_grpc_haskell_bench/Dockerfile
@@ -1,0 +1,29 @@
+FROM docker.io/library/haskell:8.10.7
+
+RUN apt-get update && apt-get install -y \
+      build-essential autoconf libtool libssl-dev pkg-config cmake git
+
+ARG PARALLEL
+RUN BUILD_DIR=$(mktemp -d) && \
+    cd $BUILD_DIR && \
+    git clone --depth 1 --branch v1.35.0 --recurse-submodules https://github.com/grpc/grpc && \
+    cd grpc && \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr \
+          -DgRPC_BUILD_TESTS=OFF \
+          -DBUILD_SHARED_LIBS=ON \
+          -DgRPC_INSTALL=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DgRPC_SSL_PROVIDER=package \
+          . && \
+    make -j ${PARALLEL:-$(nproc)} && \
+    make install -j${PARALLEL:-$(nproc)} && \
+    rm -rf $BUILD_DIR
+
+COPY haskell_grpc_haskell_bench /app/bench
+COPY proto /app/proto
+
+RUN cd /app/bench && cabal update && make && cabal install
+
+RUN rm -rf /app
+
+ENTRYPOINT /root/.cabal/bin/haskell-grpc-haskell-bench +RTS -N${GRPC_SERVER_CPUS:-1}

--- a/haskell_grpc_haskell_bench/Makefile
+++ b/haskell_grpc_haskell_bench/Makefile
@@ -1,0 +1,11 @@
+CABAL ?= cabal
+PROTO_COMPILE_HS = ~/.cabal/bin/compile-proto-file
+
+grpc-haskell:
+	($(CABAL) build proto3-suite && mkdir -p ~/.cabal/bin && \
+		$(CABAL) exec which compile-proto-file | tail -1 | xargs -I{} cp {} $(PROTO_COMPILE_HS))
+	($(PROTO_COMPILE_HS) \
+		--includeDir /usr/local/include \
+		--includeDir ../proto/helloworld \
+		--proto helloworld.proto \
+		--out ./src-gen/)

--- a/haskell_grpc_haskell_bench/app/Main.hs
+++ b/haskell_grpc_haskell_bench/app/Main.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+module Main where
+
+import           Network.GRPC.HighLevel
+import           Network.GRPC.HighLevel.Generated
+
+import           Helloworld
+
+main :: IO ()
+main =
+  greeterServer
+    (Greeter { greeterSayHello = sayHello })
+    defaultServiceOptions {serverHost = "0.0.0.0", serverPort = 50051}
+
+sayHello
+  :: ServerRequest 'Normal HelloRequest HelloReply
+  -> IO (ServerResponse 'Normal HelloReply)
+sayHello (ServerNormalRequest _metadata HelloRequest{..}) = do
+  return $ ServerNormalResponse (HelloReply helloRequestRequest) [] StatusOk ""

--- a/haskell_grpc_haskell_bench/cabal.project
+++ b/haskell_grpc_haskell_bench/cabal.project
@@ -1,0 +1,17 @@
+packages:
+  .
+
+source-repository-package
+    type: git
+    location: https://github.com/awakesecurity/gRPC-haskell.git
+    tag: 112777023f475ddd752c954056e679fbca0baa44
+
+source-repository-package
+    type: git
+    location: https://github.com/awakesecurity/gRPC-haskell.git
+    tag: 112777023f475ddd752c954056e679fbca0baa44
+    subdir: core
+
+package grpc-haskell-core
+  extra-include-dirs: /usr/local/include
+  extra-lib-dirs: /usr/local/lib

--- a/haskell_grpc_haskell_bench/grpc-haskell-bench.cabal
+++ b/haskell_grpc_haskell_bench/grpc-haskell-bench.cabal
@@ -1,0 +1,25 @@
+cabal-version: 2.4
+name:          grpc-haskell-bench
+version:       0.1.0.0
+
+executable haskell-grpc-haskell-bench
+  main-is:          Main.hs
+  hs-source-dirs:   app src-gen
+  other-modules:    Helloworld
+  build-depends:
+    , base               >=4.14 && <5
+    , bytestring
+    , containers
+    , deepseq
+    , grpc-haskell
+    , grpc-haskell-core
+    , proto3-suite       ^>=0.5
+    , proto3-wire        ^>=1.4
+    , text
+    , vector
+
+  default-language: Haskell2010
+  ghc-options:
+    -O2 -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -threaded -rtsopts


### PR DESCRIPTION
**Summary of changes**

Bench gRPC-haskell

**BTW: This Haskell implement server may have some memory leaks.**

Tested on my local machine: AMD 5900X, 64G RAM, with the following options:

```
GRPC_BENCHMARK_DURATION=120s
GRPC_BENCHMARK_WARMUP=30s
GRPC_CLIENT_CONNECTIONS=50
GRPC_CLIENT_CONCURRENCY=1000
GRPC_CLIENT_QPS=0
GRPC_CLIENT_CPUS=9
GRPC_REQUEST_SCENARIO=complex_proto
GRPC_SERVER_RAM=1g
GRPC_SERVER_CPUS=1
```

It requires `GRPC_SERVER_RAM` to be at least 1g. If I run with the default `GRPC_SERVER_RAM` (which is 512m), the container will be killed because of running out of memory.
