### PR TITLE
Migrate java_openj9_grpc_gencon_bench to IBM Semeru Runtimes 18

### DIFF
--- a/java_openj9_grpc_gencon_bench/Dockerfile
+++ b/java_openj9_grpc_gencon_bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:14.0.2_8-jre-openj9-0.21.0-bionic
+FROM ibm-semeru-runtimes:open-18.0.2_9-jdk
 
 WORKDIR /app
 COPY java_hotspot_grpc_sgc_bench/ /app


### PR DESCRIPTION
**Summary of changes**

Changes introduced in this pull request:
- Migrate the Java OpenJ9 benchmark from AdoptOpenJDK (deprecated) to [IBM Semeru Runtimes](https://developer.ibm.com/languages/java/semeru-runtimes/).

**Reference issue to close (if applicable)**

Closes #285