### PR TITLE
Bump Protobuf, gRPC versions in java_hotspot_grpc_sgc_bench

### DIFF
--- a/java_hotspot_grpc_sgc_bench/build.gradle
+++ b/java_hotspot_grpc_sgc_bench/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
     // ASSUMES GRADLE 2.12 OR HIGHER. Use plugin version 0.7.5 with earlier gradle versions
-    id 'com.google.protobuf' version '0.8.18'
+    id 'com.google.protobuf' version '0.8.19'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -22,8 +22,8 @@ targetCompatibility = 17
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.46.0' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.20.1'
+def grpcVersion = '1.49.1' // CURRENT_GRPC_VERSION
+def protobufVersion = '3.21.7'
 def protocVersion = protobufVersion
 
 dependencies {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Bump Protobuf to version 3.21.7 in `java_hotspot_grpc_sgc_bench`
- Bump Protobuf Plugin for Gradle to version 0.8.19 in `java_hotspot_grpc_sgc_bench`
- Bump gRPC to version 1.49.1 in `java_hotspot_grpc_sgc_bench`

**Other information and links**
- https://github.com/google/protobuf-gradle-plugin/releases/tag/v0.8.19
- https://github.com/protocolbuffers/protobuf/releases/tag/v21.7
- https://github.com/grpc/grpc-java/releases/tag/v1.49.1