### PR TITLE
crystal_grpc_bench/Dockerfile: bump crystal version to latest v1.7.2

### DIFF
--- a/crystal_grpc_bench/Dockerfile
+++ b/crystal_grpc_bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.5.0
+FROM crystallang/crystal:1.7.2
 
 WORKDIR /app
 COPY crystal_grpc_bench /app


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- bump crystal version to latest v1.7.2, see https://crystal-lang.org/blog/#release_notes