### PR TITLE
=vertx deploy vertical target instances to match the CPU cores.

### DIFF
--- a/java_vertx_grpc_bench/build.gradle
+++ b/java_vertx_grpc_bench/build.gradle
@@ -13,7 +13,7 @@ def protobufVersion = '3.21.6'
 def protocVersion = protobufVersion
 
 dependencies {
-    implementation 'io.vertx:vertx-grpc-server:4.4.3'
+    implementation 'io.vertx:vertx-grpc-server:4.4.4'
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"

--- a/java_vertx_grpc_bench/src/main/java/vertx/Main.java
+++ b/java_vertx_grpc_bench/src/main/java/vertx/Main.java
@@ -5,6 +5,7 @@ import io.grpc.examples.helloworld.Hello;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
@@ -14,9 +15,15 @@ import io.vertx.grpc.server.GrpcServerResponse;
 public class Main {
     public static void main(String[] args) {
         Vertx vertx = Vertx.vertx();
-        vertx.nettyEventLoopGroup().forEach(u -> {
-            vertx.deployVerticle(new ServerVerticle());
-        });
+        DeploymentOptions deploymentOptions = new DeploymentOptions();
+        int cores = Runtime.getRuntime().availableProcessors();
+        String GRPC_SERVER_CPUS = System.getenv("GRPC_SERVER_CPUS");
+        if (GRPC_SERVER_CPUS != null && GRPC_SERVER_CPUS.length() > 0) {
+            cores = Integer.parseInt(GRPC_SERVER_CPUS);
+        }
+        deploymentOptions.setInstances(cores);
+        vertx.deployVerticle(ServerVerticle::new, deploymentOptions);
+        System.out.println("Deploy vertical instances:"+cores);
     }
 
     static class ServerVerticle extends AbstractVerticle {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- 
Set the target instances of vertical to match the CPU cores.

