### PR TITLE
bolt swift repo clone to 1.21

### DIFF
--- a/swift_grpc_bench/Dockerfile
+++ b/swift_grpc_bench/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Getting protoc-gen-swift and protoc-gen-grpc-swift
 RUN apt update && apt install -y protobuf-compiler git make
-RUN git clone --depth 1 https://github.com/grpc/grpc-swift
+RUN git clone --depth 1 --single-branch --branch 1.21.0 https://github.com/grpc/grpc-swift
 WORKDIR /app/grpc-swift
 RUN make plugins
 RUN cp /app/grpc-swift/protoc-* /usr/local/bin


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- bolt the swift repo clone to 1.21, so that the build is more deterministic. It also fixes the current state of the build, where Swift bench would fail on a missing Makefile target (that file was removed recently)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. If the change is big, it would be useful to provide local benchmark results *before* and *after* -->


<!-- Thank you 🔥 -->
