### PR TITLE
Restore executor configuration for zio-grpc

### DIFF
--- a/java_hotspot_grpc_sgc_bench/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
+++ b/java_hotspot_grpc_sgc_bench/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
@@ -57,7 +57,7 @@ public class HelloWorldServer {
    * <p>
    * <ul>
    * <li>JVM_EXECUTOR_TYPE: direct, workStealing, single, fixed, cached</li>
-   * <li>JVM_EXECUTOR_THREADS: integer value.</li>
+   * <li>GRPC_SERVER_CPUS: integer value.</li>
    * </ul>
    * </p>
    *
@@ -66,7 +66,7 @@ public class HelloWorldServer {
    * this value.
    */
   private ServerBuilder<?> configureExecutor(ServerBuilder<?> sb) {
-    var threads = System.getenv("JVM_EXECUTOR_THREADS");
+    var threads = System.getenv("GRPC_SERVER_CPUS");
     var i_threads = Runtime.getRuntime().availableProcessors();
     if (threads != null && !threads.isEmpty()) {
       i_threads = Integer.parseInt(threads);

--- a/java_micronaut_workstealing_bench/src/main/java/helloworld/ServerBuilderListener.java
+++ b/java_micronaut_workstealing_bench/src/main/java/helloworld/ServerBuilderListener.java
@@ -27,7 +27,7 @@ public class ServerBuilderListener implements BeanCreatedEventListener<ServerBui
        * <p>
        * <ul>
        * <li>JVM_EXECUTOR_TYPE: direct, workStealing, single, fixed, cached</li>
-       * <li>JVM_EXECUTOR_THREADS: integer value.</li>
+       * <li>GRPC_SERVER_CPUS: integer value.</li>
        * </ul>
        * </p>
        * 
@@ -36,7 +36,7 @@ public class ServerBuilderListener implements BeanCreatedEventListener<ServerBui
        * this value.
        */
       private ServerBuilder<?> configureExecutor(ServerBuilder<?> sb) {
-        var threads = System.getenv("JVM_EXECUTOR_THREADS");
+        var threads = System.getenv("GRPC_SERVER_CPUS");
         var i_threads = Runtime.getRuntime().availableProcessors();
         if (threads != null && !threads.isEmpty()) {
           i_threads = Integer.parseInt(threads);

--- a/kotlin_grpc_bench/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
+++ b/kotlin_grpc_bench/src/main/kotlin/io/grpc/examples/helloworld/HelloWorldServer.kt
@@ -28,7 +28,7 @@ class HelloWorldServer(val port: Int) {
     val server: Server
 
     init {
-        val threads = System.getenv("JVM_EXECUTOR_THREADS")
+        val threads = System.getenv("GRPC_SERVER_CPUS")
         var i_threads = Runtime.getRuntime().availableProcessors()
         if (threads != null && !threads.isEmpty()) {
           i_threads = Integer.parseInt(threads)

--- a/scala_fs2_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
+++ b/scala_fs2_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
@@ -23,7 +23,7 @@ object GreeterServer extends IOApp {
        * <p>
        * <ul>
        * <li>JVM_EXECUTOR_TYPE: direct, workStealing, single, fixed, cached</li>
-       * <li>JVM_EXECUTOR_THREADS: integer value.</li>
+       * <li>GRPC_SERVER_CPUS: integer value.</li>
        * </ul>
        * </p>
        *
@@ -31,7 +31,7 @@ object GreeterServer extends IOApp {
        * availableProcessors(). Only the workStealing and fixed executors will use
        * this value.
        */
-      val threads = System.getenv("JVM_EXECUTOR_THREADS")
+      val threads = System.getenv("GRPC_SERVER_CPUS")
       var i_threads = Runtime.getRuntime.availableProcessors
       if (threads != null && !threads.isEmpty) i_threads = threads.toInt
       val value = System.getenv.getOrDefault("JVM_EXECUTOR_TYPE", "workStealing")

--- a/scala_zio_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
+++ b/scala_zio_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
@@ -20,7 +20,7 @@ object GreeterServer extends ServerMain {
      * <p>
      * <ul>
      * <li>JVM_EXECUTOR_TYPE: direct, workStealing, single, fixed, cached</li>
-     * <li>JVM_EXECUTOR_THREADS: integer value.</li>
+     * <li>GRPC_SERVER_CPUS: integer value.</li>
      * </ul>
      * </p>
      *
@@ -28,7 +28,7 @@ object GreeterServer extends ServerMain {
      * availableProcessors(). Only the workStealing and fixed executors will use
      * this value.
      */
-    val threads = System.getenv("JVM_EXECUTOR_THREADS")
+    val threads = System.getenv("GRPC_SERVER_CPUS")
     var i_threads = Runtime.getRuntime.availableProcessors
     if (threads != null && !threads.isEmpty) i_threads = threads.toInt
     val value = System.getenv.getOrDefault("JVM_EXECUTOR_TYPE", "workStealing")

--- a/scala_zio_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
+++ b/scala_zio_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
@@ -1,10 +1,47 @@
 package com.example.helloworld
 
+import io.grpc.ServerBuilder
+import io.grpc.protobuf.services.ProtoReflectionService
 import scalapb.zio_grpc.{ServerMain, ServiceList}
+
+import java.util.concurrent.Executors
 
 object GreeterServer extends ServerMain {
   def services: ServiceList[Any] = ServiceList.add(GreeterImpl)
 
   // Default port is 9000
   override def port = 50051
+
+  override def builder = {
+    val sb = ServerBuilder
+      .forPort(port)
+      .addService(ProtoReflectionService.newInstance())
+
+    /**
+     * Allow customization of the Executor with two environment variables:
+     *
+     * <p>
+     * <ul>
+     * <li>JVM_EXECUTOR_TYPE: direct, workStealing, single, fixed, cached</li>
+     * <li>JVM_EXECUTOR_THREADS: integer value.</li>
+     * </ul>
+     * </p>
+     *
+     * The number of Executor Threads will default to the number of
+     * availableProcessors(). Only the workStealing and fixed executors will use
+     * this value.
+     */
+    val threads = System.getenv("JVM_EXECUTOR_THREADS")
+    var i_threads = Runtime.getRuntime.availableProcessors
+    if (threads != null && !threads.isEmpty) i_threads = threads.toInt
+    val value = System.getenv.getOrDefault("JVM_EXECUTOR_TYPE", "workStealing")
+    value match {
+      case "direct" => sb.directExecutor
+      case "single" => sb.executor(Executors.newSingleThreadExecutor)
+      case "fixed" => sb.executor(Executors.newFixedThreadPool(i_threads))
+      case "workStealing" => sb.executor(Executors.newWorkStealingPool(i_threads))
+      case "cached" => sb.executor(Executors.newCachedThreadPool)
+    }
+    sb
+  }
 }

--- a/scala_zio_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
+++ b/scala_zio_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
@@ -1,8 +1,7 @@
 package com.example.helloworld
 
-import io.grpc.ServerBuilder
-import io.grpc.protobuf.services.ProtoReflectionService
-import scalapb.zio_grpc.{ServerMain, ServiceList}
+import scalapb.zio_grpc.{Server, ServerLayer, ServerMain, ServiceList}
+import zio.ZLayer
 
 import java.util.concurrent.Executors
 
@@ -12,10 +11,8 @@ object GreeterServer extends ServerMain {
   // Default port is 9000
   override def port = 50051
 
-  override def builder = {
-    val sb = ServerBuilder
-      .forPort(port)
-      .addService(ProtoReflectionService.newInstance())
+  override def serverLive: ZLayer[Any, Throwable, Server] = {
+    val sb = builder
 
     /**
      * Allow customization of the Executor with two environment variables:
@@ -42,6 +39,7 @@ object GreeterServer extends ServerMain {
       case "workStealing" => sb.executor(Executors.newWorkStealingPool(i_threads))
       case "cached" => sb.executor(Executors.newCachedThreadPool)
     }
-    sb
+
+    ServerLayer.fromServiceList(sb, services)
   }
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Restore executor configuration for zio-grpc. It was removed in https://github.com/LesnyRumcajs/grpc_bench/pull/349/files#r1233541750 but the assumption that it wasn't supported was incorrect. It is quite important because the default executor gives pretty bad results (zio should give results similar to fs2).
