### PR TITLE
Update Dart to 3.3.4 + fix deprecated

### DIFF
--- a/dart_grpc_onhold/Dockerfile
+++ b/dart_grpc_onhold/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.19.4 AS build
+FROM dart:3.3.4 AS build
 
 WORKDIR /app
 COPY dart_grpc_bench/pubspec.yaml /app/pubspec.yaml

--- a/dart_grpc_onhold/bin/server.dart
+++ b/dart_grpc_onhold/bin/server.dart
@@ -18,14 +18,12 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:grpc/grpc.dart';
-
-import 'package:helloworld/src/generated/helloworld.pb.dart';
 import 'package:helloworld/src/generated/helloworld.pbgrpc.dart';
 
 class GreeterService extends GreeterServiceBase {
   @override
   Future<HelloReply> sayHello(ServiceCall call, HelloRequest request) async {
-    return HelloReply()..response = request.request;
+    return HelloReply()..message = request.name;
   }
 }
 
@@ -46,7 +44,7 @@ Future<void> main(List<String> args) async {
 }
 
 void _startServer([List? args]) async {
-  final server = Server([GreeterService()]);
+  final server = Server.create(services: [GreeterService()]);
   await server.serve(
       address: InternetAddress.anyIPv4, port: 50051, shared: true);
 }

--- a/dart_grpc_onhold/pubspec.lock
+++ b/dart_grpc_onhold/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.10.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -61,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: grpc
-      sha256: a73c16e4f6a4a819be892bb2c73cc1d0b00e36095f69b0738cc91a733e3d27ba
+      sha256: e93ee3bce45c134bf44e9728119102358c7cd69de7832d9a874e2e74eb8cab40
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.4"
   http:
     dependency: transitive
     description:
@@ -77,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: http2
-      sha256: "58805ebc6513eed3b98ee0a455a8357e61d187bf2e0fdc1e53120770f78de258"
+      sha256: "9ced024a160b77aba8fb8674e38f70875e321d319e6f303ec18e87bd5a4b0c1d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.3.0"
   http_parser:
     dependency: transitive
     description:
@@ -125,10 +133,10 @@ packages:
     dependency: "direct main"
     description:
       name: protobuf
-      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.1.0"
   source_span:
     dependency: transitive
     description:
@@ -162,4 +170,4 @@ packages:
     source: hosted
     version: "1.3.1"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=3.3.4 <4.0.0"

--- a/dart_grpc_onhold/pubspec.yaml
+++ b/dart_grpc_onhold/pubspec.yaml
@@ -1,9 +1,9 @@
 name: helloworld
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: ^3.3.4
 
 dependencies:
   async: ^2.10.0
-  grpc: ^3.1.0
-  protobuf: ^2.1.0
+  grpc: ^3.2.4
+  protobuf: ^3.1.0


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Updated Dart version to 3.3.4 in pubspec.yaml and Dockerfile. 
- Fixed non-compiling sayHello return statement.
- Fixed deprecated Server class constructor.



**Reference issue to close (if applicable)**
Fixes #146

**Other information and links**
<!-- Add any other context about the pull request here. If the change is big, it would be useful to provide local benchmark results *before* and *after* -->


<!-- Thank you 🔥 -->
