### PR TITLE
chore: bump rust to 1.94 across the board

### DIFF
--- a/rust_grpcio_bench/Dockerfile
+++ b/rust_grpcio_bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82
+FROM rust:1.94
 
 RUN apt update && apt install -y protobuf-compiler cmake
 

--- a/rust_wtx_bench/Dockerfile
+++ b/rust_wtx_bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82
+FROM rust:1.94
 WORKDIR /app
 COPY rust_wtx_bench /app
 COPY proto /app/protos


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- bumps the remaining rust benches to Rust 1.94



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->


**Other information and links**
<!-- Add any other context about the pull request here. If the change is big, it would be useful to provide local benchmark results *before* and *after* -->


<!-- Thank you 🔥 -->
