### PR TITLE
Optimize Scala Pekko benchmark setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ payload/
 
 # Build output
 build/
+target/
+project/project/

--- a/scala_pekko_bench/build.sbt
+++ b/scala_pekko_bench/build.sbt
@@ -2,12 +2,12 @@ name := "pekko-grpc-quickstart-scala"
 
 version := "1.0"
 
-scalaVersion := "2.13.17"
+scalaVersion := "2.13.18"
 
 run / fork := true
 
-val pekkoVersion = "1.2.1"
-val pekkoHttpVersion = "1.3.0"
+val pekkoVersion = "2.0.0-M1"
+val pekkoHttpVersion = "2.0.0-M1"
 
 enablePlugins(PekkoGrpcPlugin)
 

--- a/scala_pekko_bench/project/plugins.sbt
+++ b/scala_pekko_bench/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.2.0")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "2.0.0-M1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")

--- a/scala_pekko_bench/src/main/resources/application.conf
+++ b/scala_pekko_bench/src/main/resources/application.conf
@@ -1,4 +1,6 @@
 pekko.http.server.max-connections = 1500
 pekko.http.server.preview.enable-http2 = on
 pekko.http.server.http2.min-collect-strict-entity-size = 1
+pekko.actor.default-dispatcher.fork-join-executor.parallelism-min = ${GRPC_SERVER_CPUS}
+pekko.actor.default-dispatcher.fork-join-executor.parallelism-factor = 1.0
 pekko.actor.default-dispatcher.fork-join-executor.parallelism-max = ${GRPC_SERVER_CPUS}

--- a/scala_pekko_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
+++ b/scala_pekko_bench/src/main/scala/com/example/helloworld/GreeterServer.scala
@@ -4,9 +4,8 @@ package io.grpc.examples.helloworld
 import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.scaladsl.adapter._
-import org.apache.pekko.http.scaladsl.{Http, HttpConnectionContext}
+import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse}
-import org.apache.pekko.stream.SystemMaterializer
 
 import scala.concurrent.{ExecutionContext, Future}
 //#import
@@ -26,17 +25,15 @@ class GreeterServer(implicit system: ActorSystem[_]) {
     implicit val ec: ExecutionContext = system.executionContext
 
     val service: HttpRequest => Future[HttpResponse] =
-      GreeterHandler(new GreeterServiceImpl(system))
+      GreeterHandler(new GreeterServiceImpl)
 
     println(s"Parallel: ${system.settings.config.getString("pekko.actor.default-dispatcher.fork-join-executor.parallelism-max")} GRPC_SERVER_CPUS: ${sys.env.get("GRPC_SERVER_CPUS")}")
 
     // Pekko HTTP 10.1 requires adapters to accept the new actors APIs
-    val bound = Http()(system.toClassic).bindAndHandleAsync(
-      service,
+    val bound = Http()(system.toClassic).newServerAt(
       interface = "0.0.0.0",
-      port = 50051,
-      connectionContext = HttpConnectionContext()
-    )(SystemMaterializer(system).materializer)
+      port = 50051
+    ).bind(service)
 
     bound.foreach { binding =>
       println(s"gRPC server bound to: ${binding.localAddress}")

--- a/scala_pekko_bench/src/main/scala/com/example/helloworld/GreeterServiceImpl.scala
+++ b/scala_pekko_bench/src/main/scala/com/example/helloworld/GreeterServiceImpl.scala
@@ -3,29 +3,11 @@ package io.grpc.examples.helloworld
 //#import
 import scala.concurrent.Future
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.stream.scaladsl.BroadcastHub
-import org.apache.pekko.stream.scaladsl.Keep
-import org.apache.pekko.stream.scaladsl.MergeHub
-import org.apache.pekko.stream.scaladsl.Sink
-import org.apache.pekko.stream.scaladsl.Source
-
 //#import
 
 //#service-request-reply
 //#service-stream
-class GreeterServiceImpl(system: ActorSystem[_]) extends Greeter {
-  private implicit val sys: ActorSystem[_] = system
-
-  //#service-request-reply
-  val (inboundHub: Sink[HelloRequest, NotUsed], outboundHub: Source[HelloReply, NotUsed]) =
-    MergeHub.source[HelloRequest]
-    .map(request => HelloReply(request.request))
-      .toMat(BroadcastHub.sink[HelloReply])(Keep.both)
-      .run()
-  //#service-request-reply
-
+class GreeterServiceImpl extends Greeter {
   override def sayHello(request: HelloRequest): Future[HelloReply] = {
     Future.successful(HelloReply(request.request))
   }


### PR DESCRIPTION
Motivation:
The Scala Pekko benchmark should exercise the current Apache Pekko 2.0 line and avoid extra benchmark-side overhead so future grpc_bench runs measure Pekko itself more fairly.

Modification:
- update the Scala Pekko benchmark to Scala 2.13.18 and Apache Pekko / Pekko HTTP / Pekko gRPC plugin 2.0.0-M1
- migrate server startup from removed `bindAndHandleAsync` to `newServerAt(...).bind(service)`
- remove unused MergeHub/BroadcastHub setup from the unary service implementation
- pin dispatcher min/factor/max to `GRPC_SERVER_CPUS` for predictable container CPU usage
- ignore sbt build output directories

Result:
The benchmark compiles against the Pekko 2.0 milestone stack and the unary service implementation no longer constructs unused stream hub infrastructure.

Verification:
- `sbt "set Compile / PB.protoSources += baseDirectory.value / \"../scenarios/complex_proto\"" compile`

Risk / Boundary:
- Docker was not run locally due disk-space constraint
- the change is scoped to the Scala Pekko benchmark implementation and dependency line